### PR TITLE
Feature/api domains

### DIFF
--- a/api/app/controllers/api/v1/actors_controller.rb
+++ b/api/app/controllers/api/v1/actors_controller.rb
@@ -3,8 +3,9 @@ module API::V1
     before_action :set_actor, only: :show
 
     def index
-      @actors = Actor.filter_actives.recent.includes(:localizations)
-      respond_with @actors, each_serializer: ActorArraySerializer, root: 'actors', meta: { size: @actors.size, cache_date: @actors.last_max_update }
+      @search = Search::Actors.new(params)
+      @actors = @search.results
+      respond_with @actors, each_serializer: ActorArraySerializer, root: 'actors', meta: { size: @search.total_cnt, cache_date: @actors.last_max_update }
     end
 
     def show

--- a/api/app/controllers/api/v1/acts_controller.rb
+++ b/api/app/controllers/api/v1/acts_controller.rb
@@ -3,8 +3,9 @@ module API::V1
     before_action :set_act, only: :show
 
     def index
-      @acts = Act.filter_actives.recent.includes(:localizations)
-      respond_with @acts, each_serializer: ActArraySerializer, root: 'actions', meta: { size: @acts.size, cache_date: @acts.last_max_update }
+      @search = Search::Acts.new(params)
+      @acts = @search.results
+      respond_with @acts, each_serializer: ActArraySerializer, root: 'actions', meta: { size: @search.total_cnt, cache_date: @acts.last_max_update }
     end
 
     def show

--- a/api/app/controllers/api/v1/domains_controller.rb
+++ b/api/app/controllers/api/v1/domains_controller.rb
@@ -1,0 +1,11 @@
+module API::V1
+  class DomainsController < API::ApplicationController
+    def index
+      @domains = Category.where(type: ['SocioCulturalDomain', 'OtherDomain']).
+        order(:name)
+
+      respond_with @domains, each_searializer: CategorySerializer, root: 'domains',
+        meta: { size: @domains.count }
+    end
+  end
+end

--- a/api/app/serializers/actor_array_serializer.rb
+++ b/api/app/serializers/actor_array_serializer.rb
@@ -21,7 +21,7 @@ class ActorArraySerializer < BaseSerializer
   def cache_key
     # For filter options
     cache_params = nil
-    
+
     self.class.cache_key << [object, object.updated_at, cache_params]
   end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -6,6 +6,7 @@ API::Engine.routes.draw do
       list_show_only.resources :actors
       list_show_only.resources :acts, path: 'actions'
     end
+    resources :domains, only: [:index]
   end
 # End API routes
 end

--- a/app/models/act.rb
+++ b/app/models/act.rb
@@ -29,13 +29,13 @@ class Act < ActiveRecord::Base
   has_and_belongs_to_many :socio_cultural_domains, -> { where(type: 'SocioCulturalDomain') }, class_name: 'Category'
   has_and_belongs_to_many :other_domains,          -> { where(type: 'OtherDomain')         }, class_name: 'Category'
   has_and_belongs_to_many :operational_fields,     -> { where(type: 'OperationalField')    }, class_name: 'Category'
-  
+
   accepts_nested_attributes_for :localizations,           allow_destroy: true
   accepts_nested_attributes_for :act_relations_as_child,  allow_destroy: true, reject_if: :parent_invalid
   accepts_nested_attributes_for :act_relations_as_parent, allow_destroy: true, reject_if: :child_invalid
   accepts_nested_attributes_for :act_actor_relations,     allow_destroy: true, reject_if: :actor_invalid
   accepts_nested_attributes_for :act_indicator_relations, allow_destroy: true, reject_if: :indicator_invalid
-  
+
   after_create  :set_main_location,       if: 'localizations.any?'
   after_update  :set_main_location,       if: 'localizations.any?'
   before_update :deactivate_dependencies, if: '!active and active_changed?'

--- a/app/models/search/actors.rb
+++ b/app/models/search/actors.rb
@@ -1,0 +1,39 @@
+class Search::Actors
+  attr_reader :page, :per_page
+
+  def initialize(options)
+    @id = 1
+    initialize_params(options)
+    initialize_query
+  end
+
+  def results
+    @query.limit(@per_page).
+      offset(@per_page * (@page-1)).all
+  end
+
+  def total_cnt
+    @query.count
+  end
+
+
+  private
+
+  def initialize_params(options)
+    @options = Search::ActorsParams.sanitize(options)
+    @options.keys.each { |k| instance_variable_set("@#{k}", @options[k]) }
+  end
+
+  def initialize_query
+    @query = Actor.filter_actives.recent
+
+    @query = @query.where(type: @levels) if @levels
+
+    if @socio_cultural_domains
+      @query = @query.joins(:socio_cultural_domains).
+        where(socio_cultural_domains: { id: @socio_cultural_domains })
+    end
+
+    @query = @query
+  end
+end

--- a/app/models/search/actors.rb
+++ b/app/models/search/actors.rb
@@ -31,7 +31,7 @@ class Search::Actors
 
     if @socio_cultural_domains
       @query = @query.joins(:socio_cultural_domains).
-        where(socio_cultural_domains: { id: @socio_cultural_domains })
+        where({ categories: { id: @socio_cultural_domains }})
     end
 
     @query = @query

--- a/app/models/search/actors.rb
+++ b/app/models/search/actors.rb
@@ -29,9 +29,19 @@ class Search::Actors
 
     @query = @query.where(type: @levels) if @levels
 
-    if @socio_cultural_domains
-      @query = @query.joins(:socio_cultural_domains).
-        where({ categories: { id: @socio_cultural_domains }})
+    if @socio_cultural_domains.present? || @other_domains.present?
+      @query = @query.joins(:categories).
+        where({ categories: { id: @socio_cultural_domains + @other_domains}})
+    end
+
+    if @start_date
+      @query = @query.joins(:localizations).
+        where('localizations.start_date > ?', @start_date)
+    end
+
+    if @end_date
+      @query = @query.joins(:localizations).
+        where('localizations.end_date > ?', @end_date)
     end
 
     @query = @query

--- a/app/models/search/actors_params.rb
+++ b/app/models/search/actors_params.rb
@@ -4,9 +4,9 @@ class Search::ActorsParams < Hash
       levels: params[:levels] && (params[:levels] & ["meso", "macro", "micro"]).
         present? ? params[:levels].map{|t| "Actor"+t.titleize} : nil,
       socio_cultural_domains: params[:socio_cultural_domains_ids].blank?  ?
-        nil : params[:socio_cultural_domains_ids].map(&:to_i),
+        [] : params[:socio_cultural_domains_ids].map(&:to_i),
       other_domains: params[:other_domains_ids].blank? ?
-        nil : params[:other_domains_ids].map(&:to_i),
+        [] : params[:other_domains_ids].map(&:to_i),
       start_date: params[:start_date] || nil,
       end_date: params[:end_date] || nil,
       page: params[:page] && params[:page].to_i > 0 ? params[:page].to_i : 1,

--- a/app/models/search/actors_params.rb
+++ b/app/models/search/actors_params.rb
@@ -1,0 +1,23 @@
+class Search::ActorsParams < Hash
+  def initialize(params)
+    sanitized_params = {
+      levels: params[:levels] && (params[:levels] & ["meso", "macro", "micro"]).
+        present? ? params[:levels].map{|t| "Actor"+t.titleize} : nil,
+      socio_cultural_domains: params[:socio_cultural_domains_ids].blank?  ?
+        nil : params[:socio_cultural_domains_ids],
+      other_domains: params[:other_domains_ids].blank? ?
+        nil : params[:other_domains_ids],
+      start_date: params[:start_date] || nil,
+      end_date: params[:end_date] || nil,
+      page: params[:page] && params[:page].to_i > 0 ? params[:page].to_i : 1,
+      per_page: params[:per_page] && params[:per_page].to_i > 0 ? params[:per_page].to_i : 25
+    }
+
+    super(sanitized_params)
+    self.merge!(sanitized_params)
+  end
+
+  def self.sanitize(params)
+    new(params)
+  end
+end

--- a/app/models/search/actors_params.rb
+++ b/app/models/search/actors_params.rb
@@ -4,9 +4,9 @@ class Search::ActorsParams < Hash
       levels: params[:levels] && (params[:levels] & ["meso", "macro", "micro"]).
         present? ? params[:levels].map{|t| "Actor"+t.titleize} : nil,
       socio_cultural_domains: params[:socio_cultural_domains_ids].blank?  ?
-        nil : params[:socio_cultural_domains_ids],
+        nil : params[:socio_cultural_domains_ids].map(&:to_i),
       other_domains: params[:other_domains_ids].blank? ?
-        nil : params[:other_domains_ids],
+        nil : params[:other_domains_ids].map(&:to_i),
       start_date: params[:start_date] || nil,
       end_date: params[:end_date] || nil,
       page: params[:page] && params[:page].to_i > 0 ? params[:page].to_i : 1,

--- a/app/models/search/acts.rb
+++ b/app/models/search/acts.rb
@@ -1,0 +1,47 @@
+class Search::Acts
+  attr_reader :page, :per_page
+
+  def initialize(options)
+    @id = 1
+    initialize_params(options)
+    initialize_query
+  end
+
+  def results
+    @query.limit(@per_page).
+      offset(@per_page * (@page-1)).all
+  end
+
+  def total_cnt
+    @query.count
+  end
+
+
+  private
+
+  def initialize_params(options)
+    @options = Search::ActsParams.sanitize(options)
+    @options.keys.each { |k| instance_variable_set("@#{k}", @options[k]) }
+  end
+
+  def initialize_query
+    @query = Act.filter_actives.recent
+
+    @query = @query.where(type: @levels) if @levels
+
+    if @socio_cultural_domains.present? || @other_domains.present?
+      @query = @query.joins(:categories).
+        where({ categories: { id: @socio_cultural_domains + @other_domains}})
+    end
+
+    if @start_date
+      @query = @query.where('start_date > ?', @start_date)
+    end
+
+    if @end_date
+      @query = @query.where('end_date < ?', @end_date)
+    end
+
+    @query = @query
+  end
+end

--- a/app/models/search/acts_params.rb
+++ b/app/models/search/acts_params.rb
@@ -1,0 +1,23 @@
+class Search::ActsParams < Hash
+  def initialize(params)
+    sanitized_params = {
+      levels: params[:levels] && (params[:levels] & ["meso", "macro", "micro"]).
+        present? ? params[:levels].map{|t| "Act"+t.titleize} : nil,
+      socio_cultural_domains: params[:socio_cultural_domains_ids].blank?  ?
+        [] : params[:socio_cultural_domains_ids].map(&:to_i),
+      other_domains: params[:other_domains_ids].blank? ?
+        [] : params[:other_domains_ids].map(&:to_i),
+      start_date: params[:start_date] || nil,
+      end_date: params[:end_date] || nil,
+      page: params[:page] && params[:page].to_i > 0 ? params[:page].to_i : 1,
+      per_page: params[:per_page] && params[:per_page].to_i > 0 ? params[:per_page].to_i : 25
+    }
+
+    super(sanitized_params)
+    self.merge!(sanitized_params)
+  end
+
+  def self.sanitize(params)
+    new(params)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,7 @@ module Undp
     config.autoload_paths += Dir[Rails.root.join('app', 'models', 'acts')]
     config.autoload_paths += Dir[Rails.root.join('app', 'models', 'localizations')]
     config.autoload_paths += Dir[Rails.root.join('app', 'models', 'categories')]
+    config.autoload_paths += Dir[Rails.root.join('app', 'models', 'search')]
     config.included_models = ActiveRecord::Base.descendants.map!(&:name)
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.

--- a/spec/acceptance/api/v1/actors_spec.rb
+++ b/spec/acceptance/api/v1/actors_spec.rb
@@ -60,6 +60,27 @@ resource 'Actors' do
           expect(actor_4['locations'][0]['lat']).not_to be_nil
           expect(actor_3['locations'].size).to eq(1)
         end
+
+        example_request 'Getting a list of micro actors' do
+          do_request(levels: ['micro'])
+          response_actors = JSON.parse(response_body)['actors']
+          expect(status).to eq(200)
+          expect(response_actors.size).to eq(1)
+        end
+
+        example_request 'Getting a list of micro and meso actors' do
+          do_request(levels: ['micro', 'meso'])
+          response_actors = JSON.parse(response_body)['actors']
+          expect(status).to eq(200)
+          expect(response_actors.size).to eq(2)
+        end
+
+        example_request 'Getting a list of actors with a social cultural domain' do
+          do_request(socio_cultural_domains_ids: [@category_1.id])
+          response_actors = JSON.parse(response_body)['actors']
+          expect(status).to eq(200)
+          expect(response_actors.size).to eq(2)
+        end
       end
     end
 

--- a/spec/acceptance/api/v1/acts_spec.rb
+++ b/spec/acceptance/api/v1/acts_spec.rb
@@ -52,6 +52,27 @@ resource 'Acts' do
           expect(actor_3['locations'][0]['lat']).not_to be_nil
           expect(actor_3['locations'].size).to         eq(1)
         end
+
+        example_request 'Getting a list of micro actions' do
+          do_request(levels: ['micro'])
+          response_actions = JSON.parse(response_body)['actions']
+          expect(status).to eq(200)
+          expect(response_actions.size).to eq(1)
+        end
+
+        example_request 'Getting a list of micro and meso actions' do
+          do_request(levels: ['micro', 'meso'])
+          response_actions = JSON.parse(response_body)['actions']
+          expect(status).to eq(200)
+          expect(response_actions.size).to eq(2)
+        end
+
+        example_request 'Getting a list of actions with a social cultural domain' do
+          do_request(socio_cultural_domains_ids: [@category_1.id])
+          response_actions = JSON.parse(response_body)['actions']
+          expect(status).to eq(200)
+          expect(response_actions.size).to eq(2)
+        end
       end
     end
 

--- a/spec/acceptance/api/v1/domains_spec.rb
+++ b/spec/acceptance/api/v1/domains_spec.rb
@@ -1,0 +1,30 @@
+# encoding: UTF-8
+require 'acceptance_helper'
+
+resource 'Domains' do
+  header "Accept", "application/json; application/undp-cabo-verde-v1+json"
+  header "Content-Type", "application/json"
+  header 'Host', 'undp-cabo-verde.herokuapp.com'
+
+  context 'Domains API Version 1' do
+    context 'Actors list' do
+      let!(:categories) {
+        FactoryGirl.create(:category, name: 'Category OD')
+        FactoryGirl.create(:category, name: 'Category SCD', type: 'SocioCulturalDomain')
+        FactoryGirl.create(:category, name: 'Category SCD 2', type: 'SocioCulturalDomain')
+        FactoryGirl.create(:category, name: 'Category OD 2')
+        FactoryGirl.create(:category, name: 'Derp', type: 'OrganizationType')
+        FactoryGirl.create(:category, name: 'Derp2', type: 'OrganizationType')
+      }
+      get "/api/domains" do
+        example_request 'Getting a list of domains' do
+          domains = JSON.parse(response_body)['domains']
+
+          expect(status).to eq(200)
+          expect(domains.size).to eq(4)
+          expect(Category.count).to eq(6)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates endpoint */api/domains* that provides a list of SocioCulturalDomains and OtherDomains.
Response is in the form:

````
{
  "domains": [
     {
        "id": ​6,
        "name": "Agriculture",
        "parent_id": null,
        "created_at": "2015-12-11T20:27:47.320+01:00",
        "updated_at": "2015-12-11T20:27:47.320+01:00"
     }
  ],
  "meta": {
    "size": ​1
 }
}
````

Review after: https://github.com/Vizzuality/undp_cabo_verde/pull/49