### PR TITLE
New icons for the legend and automatic fade out of the irrelevant icons

### DIFF
--- a/app/assets/javascripts/prototype/views/map_view.js
+++ b/app/assets/javascripts/prototype/views/map_view.js
@@ -42,6 +42,11 @@
       this.$relationshipsToggle = this.$el.find('.js-relationships-checkbox');
       this.$buttons = this.$el.find('#map-buttons');
       this.$credits = this.$el.find('.leaflet-control-attribution');
+      /* Cache for the relationships part of the legend */
+      this.$actorToActionLegend = this.$el.find('.js-actor-to-action');
+      this.$actorToActorLegend = this.$el.find('.js-actor-to-actor');
+      this.$actionToActionLegend = this.$el.find('.js-action-to-action');
+
       this.setListeners();
     },
 
@@ -50,7 +55,7 @@
         this.addActorsMarkers);
       this.listenTo(this.actionsCollection, 'sync change',
         this.addActionsMarkers);
-      this.listenTo(this.router, 'route', this.updateMapFromRoute);
+      this.listenTo(this.router, 'route', this.onRoute);
       this.listenTo(root.app.pubsub, 'relationships:visibility',
         this.toggleRelationshipsVisibility);
       this.listenTo(root.app.pubsub, 'sidebar:visibility',
@@ -187,6 +192,11 @@
       this.updateMarkersFocus(marker.options.type, marker.options.id,
         marker.options.locationId);
       this.renderPopupFor(marker);
+    },
+
+    onRoute: function() {
+      this.updateMapFromRoute.apply(this, arguments);
+      this.updateLegendFromRoute.apply(this, arguments);
     },
 
     /* Load the content of the passed marker and display it inside the popup
@@ -360,6 +370,27 @@
 
         default:
           this.resetMarkersFocus();
+          break;
+      }
+    },
+
+    /* Reduce the opacity of relationships parts of the legend which don't
+     * make sense on specific routes */
+    updateLegendFromRoute: function(route) {
+      switch(route) {
+        case 'actor':
+          this.$actionToActionLegend.toggleClass('-disabled', true);
+          this.$actorToActorLegend.toggleClass('-disabled', false);
+          break;
+
+        case 'action':
+          this.$actionToActionLegend.toggleClass('-disabled', false);
+          this.$actorToActorLegend.toggleClass('-disabled', true);
+          break;
+
+        default:
+          this.$actionToActionLegend.toggleClass('-disabled', false);
+          this.$actorToActorLegend.toggleClass('-disabled', false);
           break;
       }
     },

--- a/app/assets/stylesheets/prototype/layouts/_l-map.scss
+++ b/app/assets/stylesheets/prototype/layouts/_l-map.scss
@@ -40,6 +40,8 @@
         color: $color-10;
         font-size: 13px;
         line-height: 20px;
+        opacity: 1;
+        transition: opacity .3s;
 
         > .icon {
           width: 12px;
@@ -49,7 +51,7 @@
           margin-right: 5px;
 
           &.-large {
-            width: 42px;
+            width: 30px;
             padding-top: 2px;
             margin-right: 10px;
           }
@@ -64,6 +66,8 @@
           text-transform: uppercase;
           margin-bottom: 10px;
         }
+
+        &.-disabled { opacity: .3; }
       }
     }
 

--- a/app/views/layouts/prototype.html.slim
+++ b/app/views/layouts/prototype.html.slim
@@ -25,17 +25,11 @@ html lang="en"
         g id="microOutlineMarkerIcon"
           polygon points="2 19 11 4 20 19"
         g id="actorToActionIcon"
-          path d="M12,5 L30,5" stroke="#4a4a4a" stroke-width="2" stroke-dasharray="4,3"
-          circle cx="4.5" cy="4.5" r="4.5"
-          polygon points="37.5 0 42 9 33 9 "
+          path d="M0 1h30.758" stroke="#4a4a4a" stroke-width="2" stroke-dasharray="4,3" fill="none" fill-rule="evenodd"
         g id="actorToActorIcon"
-          path d="M11.3526543,5 L29.6906787,5" stroke="#4a4a4a" stroke-width="2"
-          circle cx="37.5" cy="4.5" r="4.5"
-          circle cx="4.5" cy="4.5" r="4.5"
+          path d="M.603 1h31.335" stroke="#4a4a4a" stroke-width="2" fill="none" fill-rule="evenodd"
         g id="actionToActionIcon"
-          path d="M11.3526543,5 L29.6906787,5" stroke="#4a4a4a" stroke-width="2"
-          polygon points="37.5 0 42 9 33 9 "
-          polygon points="4.5 0 9 9 0 9 "
+          path d="M.603 1h31.335" stroke="#4a4a4a" stroke-width="2" fill="none" fill-rule="evenodd"
         g id="moreInfoIcon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"
           circle fill="#222222" cx="12" cy="8" r="1"
           circle fill="#222222" cx="8" cy="8" r="1"
@@ -190,17 +184,17 @@ html lang="en"
           ul
             li.title
               = t('front.relationships')
-            li
+            li.js-actor-to-action
               svg.icon.-large.-monochrome
-                use xlink:href="#actorToActionIcon" x="0" y="0"
+                use xlink:href="#actorToActionIcon" x="0" y="4"
               = t('front.actor_to_action')
-            li
+            li.js-actor-to-actor
               svg.icon.-large.-monochrome
-                use xlink:href="#actorToActorIcon" x="0" y="0"
+                use xlink:href="#actorToActorIcon" x="0" y="4"
               = t('front.actor_to_actor')
-            li
+            li.js-action-to-action
               svg.icon.-large.-monochrome
-                use xlink:href="#actionToActionIcon" x="0" y="0"
+                use xlink:href="#actionToActionIcon" x="0" y="4"
               = t('front.action_to_action')
         #map-buttons
           .checkbox.-reversed.-negative


### PR DESCRIPTION
Minor PR.

NEW:
* Add a feature that automatically hides the irrelevant part of the legends when viewing a specific page. For example, when seeing a specific actor, the item "Action to Action" fades out on the legend.

CHANGE:
* New icons for the relationships.