### PR TITLE
Bug/map consistency

### DIFF
--- a/app/assets/javascripts/prototype.js
+++ b/app/assets/javascripts/prototype.js
@@ -84,15 +84,19 @@
       this.listenTo(this.router, 'route:action', this.fetchFilteredCollections);
       this.listenTo(this.router, 'route:about', this.aboutPage);
       this.listenTo(this.router, 'change:queryParams',
-        this.fetchFilteredCollections);
+        this.onQueryParamsChange);
     },
 
     aboutPage: function() {
 
     },
 
+    onQueryParamsChange: function() {
+      this.fetchFilteredCollections({ force: true });
+    },
+
     /* Fetch only the collections that are not filtered out */
-    fetchFilteredCollections: function() {
+    fetchFilteredCollections: function(options) {
       var queryParams = this.router.getQueryParams();
 
       /* If one of the required filter doesn't have any value, we just don't
@@ -104,10 +108,12 @@
         return;
       }
 
+      var params = _.extend({}, options || {});
       if(!queryParams.types || queryParams.types.length === 2) {
-        this.fetchCollections({ force: true });
+        this.fetchCollections(params);
       } else {
-        this.fetchCollections({ force: true, only: queryParams.types[0] });
+        params.only = queryParams.types[0];
+        this.fetchCollections(params);
       }
     },
 

--- a/app/assets/javascripts/prototype/router.js
+++ b/app/assets/javascripts/prototype/router.js
@@ -18,12 +18,28 @@
 
     initialize: function() {
       this.queryParams = new QueryParams();
+      this.currentRoute = { name: null, params: [] };
+
       this.retrieveQueryParams();
       this.setListeners();
     },
 
     setListeners: function() {
       this.listenTo(this.queryParams, 'change', this.queryParamsOnChange);
+      this.listenTo(this, 'route', this.saveCurrentRoute);
+    },
+
+    /* Save the current route and its parameters */
+    saveCurrentRoute: function() {
+      this.currentRoute = {
+        name: arguments[0],
+        params: [].slice.call(arguments, 1)[0]
+      };
+    },
+
+    /* Return the current route */
+    getCurrentRoute: function() {
+      return this.currentRoute;
     },
 
     /* Save the query params passed as argument inside the queryParams model */

--- a/app/assets/javascripts/prototype/views/map_view.js
+++ b/app/assets/javascripts/prototype/views/map_view.js
@@ -122,6 +122,9 @@
         });
       };
 
+      /* We close the current popup if exists */
+      this.map.closePopup();
+
       var marker, popup;
       _.each(collection, function(entity) {
         _.each(entity.locations, function(location) {

--- a/app/assets/javascripts/prototype/views/map_view.js
+++ b/app/assets/javascripts/prototype/views/map_view.js
@@ -83,6 +83,10 @@
         });
 
         this.map.zoomControl.setPosition('bottomleft');
+
+        /* The map fires a click event when it's clicked outside of a marker. In
+         * that case, we want to remove the focus on all the markers. */
+        this.map.on('click', this.resetMarkersFocus.bind(this));
       }
 
       this.isMapInstanciated = false;

--- a/app/assets/javascripts/prototype/views/map_view.js
+++ b/app/assets/javascripts/prototype/views/map_view.js
@@ -83,10 +83,7 @@
         });
 
         this.map.zoomControl.setPosition('bottomleft');
-
-        /* The map fires a click event when it's clicked outside of a marker. In
-         * that case, we want to remove the focus on all the markers. */
-        this.map.on('click', this.resetMarkersFocus.bind(this));
+        this.map.on('click', this.onMapClick.bind(this));
       }
 
       this.isMapInstanciated = false;
@@ -100,6 +97,15 @@
         .on('error', function(error) {
           console.error('Unable to render the map: ' + error);
         });
+    },
+
+    onMapClick: function() {
+      var route = this.router.getCurrentRoute();
+      if(route.name === 'welcome' || route.name === 'about') {
+        this.resetMarkersFocus();
+      } else {
+        this.updateMarkersFocus.apply(this, [route.name + 's'].concat(route.params));
+      }
     },
 
     /* Add markers for each location of each entity of the collection. Depending

--- a/app/assets/javascripts/prototype/views/sidebar_view.js
+++ b/app/assets/javascripts/prototype/views/sidebar_view.js
@@ -30,6 +30,7 @@
       this.listenTo(this.status, 'change:isHidden', this.triggerVisibility);
       this.listenTo(this.tabNavigationView, 'tab:change', this.switchContent);
       this.listenTo(this.router, 'route:actor', this.show);
+      this.listenTo(this.router, 'route:action', this.show);
       this.$toggleSwitch.on('click', this.toggle.bind(this));
     },
 


### PR DESCRIPTION
Fixes various small UI issues related to the map.

FIXES:
* When the user would open a marker's popup and then close it, the marker's focus would stay
* Opening a marker's information in the sidebar would reload the collections and remove the marker's focus
* Opening a marker's information in the sidebar wouldn't expand it
* The user could open a popup, filter the map's markers (to remove the marker attached to it) and open its details in the sidebar, which would lead to a warning in the console because the marker disappeared
* The focus on a marker could be lost when its details would be opened in the sidebar and the user would click on another marker (now, if the user clicks outside of any marker, the focus returns)