### PR TITLE
Refactors the events flow/architecture to prevent asynchronous issues

### DIFF
--- a/app/assets/javascripts/prototype.js
+++ b/app/assets/javascripts/prototype.js
@@ -45,22 +45,12 @@
 
     initialize: function() {
       this.router = new root.app.Router();
-
-      this.actorsCollection = new root.app.Collection.actorsCollection(null, {
-        router: this.router
-      });
-      this.actionsCollection = new root.app.Collection.actionsCollection(null, {
-        router: this.router
-      });
+      Backbone.history.start({ pushState: false });
 
       this.mapView = new root.app.View.mapView({
-        actorsCollection: this.actorsCollection,
-        actionsCollection: this.actionsCollection,
         router: this.router
       });
       this.sidebarView = new root.app.View.sidebarView({
-        actorsCollection: this.actorsCollection,
-        actionsCollection: this.actionsCollection,
         router: this.router
       });
       this.sidebarActionToolbarView = new root.app.View.sidebarActionToolbarView({
@@ -75,72 +65,10 @@
       this.actionView = new root.app.View.sidebarActionView({
         router: this.router
       });
-
-      this.setListeners();
-    },
-
-    setListeners: function() {
-      this.listenTo(this.router, 'route:welcome',
-        this.fetchFilteredCollections);
-      this.listenTo(this.router, 'route:actor', this.fetchFilteredCollections);
-      this.listenTo(this.router, 'route:action', this.fetchFilteredCollections);
-      this.listenTo(this.router, 'route:about', this.aboutPage);
-      this.listenTo(this.router, 'change:queryParams',
-        this.onQueryParamsChange);
-    },
-
-    aboutPage: function() {
-
-    },
-
-    onQueryParamsChange: function() {
-      this.fetchFilteredCollections({ force: true });
-    },
-
-    /* Fetch only the collections that are not filtered out */
-    fetchFilteredCollections: function(options) {
-      var queryParams = this.router.getQueryParams();
-
-      /* If one of the required filter doesn't have any value, we just don't
-       * fetch the collections, the user will see a warning in the sidebar
-       * anyway */
-      if(queryParams.types && queryParams.types.length === 0 ||
-        queryParams.levels && queryParams.levels.length === 0 ||
-        queryParams.domains_ids && queryParams.domains_ids.length === 0) {
-        return;
-      }
-
-      var params = _.extend({}, options || {});
-      if(!queryParams.types || queryParams.types.length === 2) {
-        this.fetchCollections(params);
-      } else {
-        params.only = queryParams.types[0];
-        this.fetchCollections(params);
-      }
-    },
-
-    /* Fetch the actor and actions collections if empty
-     * Options:
-     *  - force (boolean): force the collections to be fetched
-     *  - only ("actors" or "actions"): restrict the fetch to only one
-     *    collection */
-    fetchCollections: function(options) {
-      if((this.actorsCollection.length === 0 || options && options.force) &&
-        (!(options && options.only) || options && options.only === 'actors')) {
-        this.actorsCollection.fetch();
-      }
-      if((this.actionsCollection.length === 0 || options && options.force) &&
-        (!(options && options.only) || options && options.only === 'actions')) {
-        this.actionsCollection.fetch();
-      }
-    },
-
-    start: function() {
-      Backbone.history.start({ pushState: false });
     }
 
   });
 
-  new app.AppView().start();
+  new app.AppView();
 
 })(this);

--- a/app/assets/javascripts/prototype/router.js
+++ b/app/assets/javascripts/prototype/router.js
@@ -12,8 +12,8 @@
     routes: {
       '(/)': 'welcome',
       'about(/)': 'about',
-      'actors/:id/:locationId(/)': 'actor',
-      'actions/:id/:locationId(/)': 'action'
+      'actors/:id/:locationId(/)': 'actors',
+      'actions/:id/:locationId(/)': 'actions'
     },
 
     initialize: function() {

--- a/app/assets/javascripts/prototype/views/map_view.js
+++ b/app/assets/javascripts/prototype/views/map_view.js
@@ -61,6 +61,7 @@
       this.listenTo(root.app.pubsub, 'sync:actionModel',
         this.onActionModelRemoteSync);
       this.listenTo(this.router, 'change:queryParams', this.onFiltering);
+      this.listenTo(root.app.pubsub, 'click:goBack', this.onGoBack);
     },
 
     /* GETTERS */
@@ -205,6 +206,11 @@
 
       this.actionModel.clear({ silent: true });
       this.actionModel.set(model.toJSON());
+    },
+
+    onGoBack: function() {
+      this.map.closePopup();
+      this.resetMarkersHighlight();
     },
 
     /* LOGIC */

--- a/app/assets/javascripts/prototype/views/map_view.js
+++ b/app/assets/javascripts/prototype/views/map_view.js
@@ -19,24 +19,20 @@
     popupTemplate: HandlebarsTemplates['popup_template'],
 
     initialize: function(options) {
-      this.actorsCollection = options.actorsCollection;
-      this.actionsCollection = options.actionsCollection;
+      this.router = options.router;
+
+      this.actorsCollection = new root.app.Collection.actorsCollection(null, {
+        router: this.router
+      });
+      this.actionsCollection = new root.app.Collection.actionsCollection(null, {
+        router: this.router
+      });
       /* actorModel and actionModel are used to store the information about the
        * maker whose popup is open. Their data can be fetched by this view, or
        * synced by another one using the pubsub object. */
       this.actorModel = new root.app.Model.actorModel();
       this.actionModel = new root.app.Model.actionModel();
-      this.router = options.router;
-      /* queue is an array of methods and arguments ([ func, args ]) that is
-       * stored in order to wait for the map to be instanced. Once done, each
-       * queue's methods are called. The queue's elements have a priority number
-       * so the ones with the smallest number are executed first (FIFO). */
-      this.queue = [];
-      this.renderMap();
-      /* We make a first call to addMarkers in order to make sure to add them
-       * in case the collection would be populated before the view would be
-       * instanced */
-      this.addActorsMarkers();
+
       this.$legend = this.$el.find('#map-legend');
       this.$zoomButtons = this.$el.find('.leaflet-control-zoom');
       this.$relationshipsToggle = this.$el.find('.js-relationships-checkbox');
@@ -48,70 +44,274 @@
       this.$actionToActionLegend = this.$el.find('.js-action-to-action');
 
       this.setListeners();
+
+      this.initMap();
     },
 
     setListeners: function() {
-      this.listenTo(this.actorsCollection, 'sync change',
-        this.addActorsMarkers);
-      this.listenTo(this.actionsCollection, 'sync change',
-        this.addActionsMarkers);
-      this.listenTo(this.router, 'route', this.onRoute);
       this.listenTo(root.app.pubsub, 'relationships:visibility',
-        this.toggleRelationshipsVisibility);
+        this.onRelationshipsVisibilityChange);
       this.listenTo(root.app.pubsub, 'sidebar:visibility',
-        this.slideButtons);
-      this.map.on('zoomend', this.updateMarkersSize.bind(this));
-      this.listenTo(this.actorModel, 'sync', this.triggerActorModelSync);
-      this.listenTo(this.actionModel, 'sync', this.triggerActionModelSync);
+        this.onSidebarVisibilityChange);
+
+      this.listenTo(this.actorModel, 'sync', this.onActorModelSync);
+      this.listenTo(this.actionModel, 'sync', this.onActionModelSync);
       this.listenTo(root.app.pubsub, 'sync:actorModel',
-        this.populateActorModelFrom);
+        this.onActorModelRemoteSync);
       this.listenTo(root.app.pubsub, 'sync:actionModel',
-        this.populateActionModelFrom);
+        this.onActionModelRemoteSync);
       this.listenTo(this.router, 'change:queryParams', this.onFiltering);
     },
 
-    renderMap: function() {
-      if(!this.map) {
-        this.map = new L.Map('map', {
-          center: [14.91, -23.51],
-          zoom: 13,
-          minZoom: 8,
-          maxBounds: [
-            L.latLng(13.637819, -28.389729),
-            L.latLng(18.228372, -19.292213)
-          ]
-        });
+    /* GETTERS */
 
-        this.map.zoomControl.setPosition('bottomleft');
-        this.map.on('click', this.onMapClick.bind(this));
+    /* Return the marker (DOM element) corresponding at the type, id and
+     * locationId passed as arguments. If not found, display a warning in the
+     * console. */
+    getMarker: function(type, id, locationId) {
+      var entityClass = type === 'actors' ? '.js-actor-marker' :
+        '.js-action-marker';
+      var selector = entityClass + '[data-id="' + id + '"]' +
+        (locationId ? '[data-location="' + locationId + '"]' : '');
+
+      var marker = document.querySelector(selector);
+      if(!marker) {
+        console.warn('Unable to find the marker /' +
+          [ route.name, id, locationId ].join('/'));
+      }
+      return marker;
+    },
+
+    /* Return the marker (DOM element) associated to the actor/action present in
+     * the URL.
+     * NOTE: if there isn't any actor/action present in the URL or if the marker
+     * can't be found, return undefined (and a warning when can't be found) */
+    getActiveMarker: function() {
+      var route = this.router.getCurrentRoute();
+      var marker;
+
+      if(route.name === 'actors' || route.name === 'actions') {
+        marker = this.getMarker(route.name, route.params[0], route.params[1]);
       }
 
-      this.isMapInstanciated = false;
-      cartodb.createLayer(this.map,
-        'https://simbiotica.cartodb.com/api/v2/viz/d26b8254-78d1-11e5-b910-0ecfd53eb7d3/viz.json')
-        .addTo(this.map)
-        .on('done', function() {
-          this.isMapInstanciated = true;
-          this.applyQueue();
-        }.bind(this))
-        .on('error', function(error) {
-          console.error('Unable to render the map: ' + error);
-        });
+      return marker;
     },
+
+    /* Return all the map's highlighted markers as a NodeList */
+    getAllHighlightedMarkers: function() {
+      var selector = '.js-actor-marker.-active, .js-action-marker.-active';
+      return document.querySelectorAll(selector);
+    },
+
+    /* EVENT HANDLERS */
 
     onMapClick: function() {
       var route = this.router.getCurrentRoute();
-      if(route.name === 'welcome' || route.name === 'about') {
-        this.resetMarkersFocus();
-      } else {
-        this.updateMarkersFocus.apply(this, [route.name + 's'].concat(route.params));
+
+      this.resetMarkersHighlight();
+      this.updateLegendRelationships();
+      if(route.name === 'actions' || route.name === 'actors') {
+        this.highlightActiveMarker();
       }
     },
 
-    /* Add markers for each location of each entity of the collection. Depending
-     * on the type ("actors" or "actions"), the attributes and callbacks of the
-     * markers will differ. */
-    addMarkers: function(collection, type) {
+    onMarkerClick: function(e) {
+      var marker = this.getMarker(e.target.options.type, e.target.options.id,
+        e.target.options.locationId);
+
+      this.resetMarkersHighlight();
+      this.highlightMarker(marker);
+      this.renderPopupFor(e.target);
+      this.updateLegendRelationships(e.target);
+    },
+
+    onMoreInfoButtonClick: function(marker) {
+      this.router.navigate([
+        '/' + marker.options.type,
+        marker.options.id,
+        marker.options.locationId
+      ].join('/'), { trigger: true });
+
+      root.app.pubsub.trigger('show:' + marker.options.type.slice(0, -1), {
+        id: marker.options.id,
+        locationId: marker.options.locationId
+      });
+
+      this.map.closePopup(marker.getPopup());
+    },
+
+    onFiltering: function() {
+      this.map.closePopup();
+      this.fetchFilteredCollections()
+        .then(function() {
+          this.removeMarkers();
+          this.addFilteredMarkers();
+          this.updateLegendRelationships();
+        }.bind(this));
+    },
+
+    onRelationshipsVisibilityChange: function(options) {
+      var isVisible = options.visible;
+      /* We toggle the part concerning the relationships from the legend */
+      this.$legend.toggleClass('-reduced', !isVisible);
+      /* We move the zoom buttons according to the legend move */
+      this.$zoomButtons.toggleClass('-slided', !isVisible);
+      /* We toggle the switch button concerning the relationships */
+      this.$relationshipsToggle.prop('checked', isVisible);
+      /* TODO: implementation of the method */
+      console.warn('Feature not yet implemented');
+    },
+
+    onSidebarVisibilityChange: function(options) {
+      this.$buttons.toggleClass('-slided', options.isHidden);
+      this.$credits.toggleClass('-slided', options.isHidden);
+    },
+
+    /* Trigger an event through the pubsub object to inform about the new state
+     * of the actor model */
+    onActorModelSync: function() {
+      root.app.pubsub.trigger('sync:actorModel', this.actorModel);
+    },
+
+    /* Trigger an event through the pubsub object to inform about the new state
+     * of the action model */
+    onActionModelSync: function() {
+      root.app.pubsub.trigger('sync:actionModel', this.actionModel);
+    },
+
+    /* Set the content of this.actorModel with the content of the passed model
+     * NOTE: as the view itself can trigger this method by the sync event of its
+     * own model, we make the comprobation that the id of the passed model is
+     * different from the one stored in the current model */
+    onActorModelRemoteSync: function(model) {
+      if(!_.isEmpty(this.actorModel.attributes) &&
+        this.actorModel.get('id') === model.get('id')) {
+        return;
+      }
+
+      this.actorModel.clear({ silent: true });
+      this.actorModel.set(model.toJSON());
+    },
+
+    /* Set the content of this.actionModel with the content of the passed model
+     * NOTE: as the view itself can trigger this method by the sync event of its
+     * own model, we make the comprobation that the id of the passed model is
+     * different from the one stored in the current model */
+    onActionModelRemoteSync: function(model) {
+      if(!_.isEmpty(this.actionModel.attributes) &&
+        this.actionModel.get('id') === model.get('id')) {
+        return;
+      }
+
+      this.actionModel.clear({ silent: true });
+      this.actionModel.set(model.toJSON());
+    },
+
+    /* LOGIC */
+
+    initMap: function() {
+      this.renderMap()
+        .then(this.fetchFilteredCollections.bind(this))
+        .then(function() {
+          this.addFilteredMarkers();
+          this.highlightActiveMarker();
+          this.updateLegendRelationships();
+        }.bind(this));
+    },
+
+    /* Render the map and return a deferred */
+    renderMap: function() {
+      this.map = new L.Map('map', {
+        center: [14.91, -23.51],
+        zoom: 13,
+        minZoom: 8,
+        maxBounds: [
+          L.latLng(13.637819, -28.389729),
+          L.latLng(18.228372, -19.292213)
+        ]
+      });
+
+      this.map.zoomControl.setPosition('bottomleft');
+      this.map.on('click', this.onMapClick.bind(this));
+      this.map.on('zoomend', this.updateMarkersSize.bind(this));
+
+      var deferred = $.Deferred();
+      cartodb.createLayer(this.map,
+        'https://simbiotica.cartodb.com/api/v2/viz/d26b8254-78d1-11e5-b910-0ecfd53eb7d3/viz.json')
+        .addTo(this.map)
+        .on('done', deferred.resolve)
+        .on('error', function(error) {
+          console.error('Unable to render the map: ' + error);
+          deferred.reject();
+        });
+
+      return deferred;
+    },
+
+    /* Fetch only the collections that are not filtered out and return a
+     * deferred object */
+    fetchFilteredCollections: function() {
+      var queryParams = this.router.getQueryParams();
+
+      /* If one of the required filter doesn't have any value, we just don't
+       * fetch the collections, the user will see a warning in the sidebar
+       * anyway */
+      if(queryParams.types && queryParams.types.length === 0 ||
+        queryParams.levels && queryParams.levels.length === 0 ||
+        queryParams.domains_ids && queryParams.domains_ids.length === 0) {
+        console.error('A required parameter hasn\'t been provided');
+        return;
+      }
+
+      var params = {};
+      if(queryParams.types && queryParams.types.length !== 2) {
+        params.only = queryParams.types[0];
+      }
+
+      return this.fetchCollections(params);
+    },
+
+    /* Fetch the actors and actions collections and returns a deferred object
+     * Options:
+     *  - only ("actors" or "actions"): restrict the fetch to only one
+     *    collection */
+    fetchCollections: function(options) {
+      var collectionsToFetch = [];
+
+      if(!(options && options.only) || options && options.only === 'actors') {
+        collectionsToFetch.push(this.actorsCollection);
+      }
+      if(!(options && options.only) || options && options.only === 'actions') {
+        collectionsToFetch.push(this.actionsCollection);
+      }
+
+      var deferred = $.Deferred();
+      $.when.apply(null, _.invoke(collectionsToFetch, 'fetch'))
+        .done(deferred.resolve)
+        .fail(function() {
+          console.error('Unable to fetch the collections');
+          deferred.reject();
+        });
+
+      return deferred;
+    },
+
+    /* Only add the markers of the collections that haven't been filtered out */
+    addFilteredMarkers: function() {
+      var queryParams = this.router.getQueryParams();
+
+      var params = {};
+      if(queryParams.types && queryParams.types.length !== 2) {
+        params.only = queryParams.types[0];
+      }
+
+      this.addMarkers(params);
+    },
+
+    /* Add markers for each location of each entity of the collection.
+    * Options:
+    *  - only ("actors" or "actions"): restrict to only one collection */
+    addMarkers: function(options) {
       /* Return the icon corresponding to each specific entity and location */
       var makeIcon = function(type, level, id, locationId) {
         return L.divIcon({
@@ -128,87 +328,72 @@
         });
       };
 
+      /* Method which actually adds the markers. Expects the collection (the
+       * JSON object) and the type ("actions" or "actions") */
+      var addEntityMarkers = function(collection, type) {
+        var marker, popup;
+        _.each(collection, function(entity) {
+          _.each(entity.locations, function(location) {
+
+            marker = L.marker([location.lat, location.long], {
+              icon: makeIcon(type, entity.level, entity.id, location.id),
+              type: type,
+              id: entity.id,
+              locationId: location.id
+            });
+            marker.addTo(this.map);
+
+            /* We bind the basic popup */
+            popup = L.popup({
+              closeButton: false,
+              minWidth: 220,
+              maxWidth: 276, /* 20px padding + 4 icons */
+              className: 'popup -' + type + ' -' + entity.level
+            }).setContent('<div class="message -loading"><svg class="icon">' +
+               '<use xlink:href="#waitIcon" x="0" y="0" /></svg>' +
+               I18n.translate('front.loading') +
+               '</message>');
+            marker.bindPopup(popup);
+
+            marker.on('click', this.onMarkerClick.bind(this));
+          }, this);
+        }, this);
+      };
+
       /* We close the current popup if exists */
       this.map.closePopup();
 
-      var marker, popup;
-      _.each(collection, function(entity) {
-        _.each(entity.locations, function(location) {
-          marker = L.marker([location.lat, location.long], {
-            icon: makeIcon(type, entity.level, entity.id, location.id),
-            type: type,
-            id: entity.id,
-            locationId: location.id
-          });
-          marker.addTo(this.map);
-          /* TODO: give an initial state to the popup */
-          popup = L.popup({
-            closeButton: false,
-            minWidth: 220,
-            maxWidth: 276, /* 20px padding + 4 icons */
-            className: 'popup -' + type + ' -' + entity.level
-          }).setContent('');
-          marker.bindPopup(popup);
-          marker.on('click', this.markerOnClick.bind(this));
-        }, this);
-      }, this);
-    },
-
-    /* Delete the selected type of markers */
-    removeMarkers: function(type) {
-      var selector = type === 'actors' ? '.js-actor-marker' :
-        '.js-action-marker';
-      /* We actually remove the parent of the marker because leaflet adds a
-       * wrapper */
-      this.$el.find(selector).parent().remove();
-    },
-
-    /* Add the markers for the actors
-     * NOTE: we should debounce the method so it's not called twice because the
-     * collection gets populated right after this view is instanciated, but this
-     * cause the priority order to not be respected when applying the queue */
-    addActorsMarkers: function() {
-      if(!this.isMapInstanciated) {
-        this.queue.push([ this.addActorsMarkers, null, 1 ]);
-        return;
+      if(!(options && options.only) || options && options.only === 'actors') {
+        addEntityMarkers.apply(this,
+          [ this.actorsCollection.toJSON(), 'actors' ]);
       }
-
-      /* We remove the previous markers in case the method has been called
-       * multiple times
-       * TODO: instead of removing and adding once again the markers, just add
-       * them once */
-      this.removeMarkers('actors');
-      this.addMarkers(this.actorsCollection.toJSON(), 'actors');
-    },
-
-    /* Add the markers for the actions
-     * NOTE: we should debounce the method so it's not called twice because the
-     * collection gets populated right after this view is instanciated, but this
-     * cause the priority order to not be respected when applying the queue */
-    addActionsMarkers: function() {
-      if(!this.isMapInstanciated) {
-        this.queue.push([ this.addActionsMarkers, null, 1 ]);
-        return;
+      if(!(options && options.only) || options && options.only === 'actions') {
+        addEntityMarkers.apply(this,
+          [ this.actionsCollection.toJSON(), 'actions' ]);
       }
-
-      /* We remove the previous markers in case the method has been called
-       * multiple times
-       * TODO: instead of removing and adding once again the markers, just add
-       * them once */
-      this.removeMarkers('actions');
-      this.addMarkers(this.actionsCollection.toJSON(), 'actions');
     },
 
-    /* Triggers an event with the id of the clicked entity */
-    markerOnClick: function(e) {
-      var marker = e.target;
-      this.updateMarkersFocus(marker.options.type, marker.options.id);
-      this.renderPopupFor(marker);
+    /* Highlight the marker associated to the actor/action present in the URL if
+     * exists, otherwise do nothing */
+    highlightActiveMarker: function() {
+      var activeMarker = this.getActiveMarker();
+
+      if(!!activeMarker) {
+        this.highlightMarker(activeMarker);
+      }
     },
 
-    onRoute: function() {
-      this.updateMapFromRoute.apply(this, arguments);
-      this.updateLegendFromRoute.apply(this, arguments);
+    /* Highlight the marker passed as argument */
+    highlightMarker: function(marker) {
+      marker.classList.add('-active');
+    },
+
+    /* Remove the highlight effects to all the map's markers */
+    resetMarkersHighlight: function() {
+      var highlightedMarkers = this.getAllHighlightedMarkers();
+      for(var i = 0, j = highlightedMarkers.length; i < j; i++) {
+        highlightedMarkers[i].classList.remove('-active');
+      }
     },
 
     /* Load the content of the passed marker and display it inside the popup
@@ -232,87 +417,55 @@
       var render = function() {
         popup.setContent(this.popupTemplate(model.toJSON()));
         this.$el.find('.js-more').on('click', function() {
-          this.moreInfoOnClick(marker);
+          this.onMoreInfoButtonClick(marker);
         }.bind(this));
       }.bind(this);
 
-      /* Before fetching the model and getting the data, we fill the popup
-       * with a loader */
-       popup.setContent('<div class="message -loading"><svg class="icon">' +
-        '<use xlink:href="#waitIcon" x="0" y="0" /></svg>' +
-        I18n.translate('front.loading') +
-        '</message>');
-
       /* In case we already have the data for the selected marker, we don't want
        * to fetch the model again */
-      if(!_.isEmpty(model.attributes) && model.get('id') === marker.options.id) {
+      if(!_.isEmpty(model.attributes) &&
+        model.get('id') === marker.options.id) {
         render();
       } else {
         model.setId(marker.options.id);
-        model.fetch().done(function() { render(); }.bind(this));
+        model.fetch().done(function() { render(); });
       }
     },
 
-    /* When the more info button of the popup attached to the marker is clicked,
-     * update the URL and close the popup
-     */
-    moreInfoOnClick: function(marker) {
-      this.router.navigate([
-        marker.options.type === 'actors' ? '/actors' : '/actions',
-        marker.options.id,
-        marker.options.locationId
-      ].join('/'), { trigger: true });
-
-      this.map.closePopup(marker.getPopup());
-    },
-
-    /* Trigger an event through the pubsub object to inform about the new state
-     * of the actor model */
-    triggerActorModelSync: function() {
-      root.app.pubsub.trigger('sync:actorModel', this.actorModel);
-    },
-
-    /* Trigger an event through the pubsub object to inform about the new state
-     * of the action model */
-    triggerActionModelSync: function() {
-      root.app.pubsub.trigger('sync:actionModel', this.actionModel);
-    },
-
-    /* Set the content of this.actorModel with the content of the passed model
-     * NOTE: as the view itself can trigger this method by the sync event of its
-     * own model, we make the comprobation that the id of the passed model is
-     * different from the one stored in the current model */
-    populateActorModelFrom: function(model) {
-      if(!_.isEmpty(this.actorModel.attributes) &&
-        this.actorModel.get('id') === model.get('id')) {
-        return;
+    /* Dynamically hide a part of the relationships legend depending on the
+     * active marker type: if a marker is passed as parameter (Leaflet object),
+     * consider it as the active marker, otherwise, take into account the marker
+     * attached to the current URL. If there's no active marker, reset the
+     * legend in its original state */
+    updateLegendRelationships: function(marker) {
+      if(marker) {
+        this.$actionToActionLegend.toggleClass('-disabled',
+          marker.options.type === 'actors');
+        this.$actorToActorLegend.toggleClass('-disabled',
+          marker.options.type === 'actions');
+      } else {
+        var route = this.router.getCurrentRoute();
+        this.$actionToActionLegend.toggleClass('-disabled',
+          route.name === 'actors');
+        this.$actorToActorLegend.toggleClass('-disabled',
+          route.name === 'actions');
       }
-
-      this.actorModel.clear({ silent: true });
-      this.actorModel.set(model.toJSON());
     },
 
-    /* Set the content of this.actionModel with the content of the passed model
-     * NOTE: as the view itself can trigger this method by the sync event of its
-     * own model, we make the comprobation that the id of the passed model is
-     * different from the one stored in the current model */
-    populateActionModelFrom: function(model) {
-      if(!_.isEmpty(this.actionModel.attributes) &&
-        this.actionModel.get('id') === model.get('id')) {
-        return;
+    /* Delete all the map's markers or only one type of markers if specified */
+    removeMarkers: function(type) {
+      var selector = '.js-actor-marker, .js-action-marker';
+      if(type) {
+        selector = (type === 'actors') ? selector.split(', ')[0] :
+          selector.split(', ')[1];
       }
-
-      this.actionModel.clear({ silent: true });
-      this.actionModel.set(model.toJSON());
+      /* We actually remove the parent of the marker because leaflet adds a
+       * wrapper */
+      this.$el.find(selector).parent().remove();
     },
 
     /* Update the markers' size according to the map's zoom level */
     updateMarkersSize: function() {
-      if(!this.isMapInstanciated) {
-        this.queue.push([this.updateMarkersSize, null, 2]);
-        return;
-      }
-
       var zoom = this.map.getZoom();
       /* We don't want the markers to be smaller than 5px but also no bigger
        * than 12px. To do so, we use the css transform: scale property and bound
@@ -326,156 +479,10 @@
        this.$el.find('.map-marker').css('transform', 'scale(' + scale + ')');
     },
 
-    /* Remove the focus styles to all the actors or actions markers depending on
-     * the value of type ("actors" or "actions").
-     * NOTE: If type is null or undefined the focus is removed from all
-     * markers. */
-    resetMarkersFocus: function(type) {
-      var selector = '.js-actor-marker, .js-action-marker';
-      if(type && type === 'actors') {
-        selector = selector.split(' ')[0].slice(0, -1);
-      } else if(type && type === 'actions') {
-        selector = selector.split(' ')[1];
-      }
-
-      var markers = this.$el.find(selector);
-      for(var i = 0, j = markers.length; i < j; i++) {
-        markers[i].classList.remove('-active');
-      }
-    },
-
-    /* Add the focus styles to the entity's marker which id and location id is
-     * passed as argument
-     * NOTE: the location id is optional */
-    focusOnMarker: function(type, id, locationId) {
-      //debugger;
-      var entityClass = type === 'actors' ? '.js-actor-marker' :
-        '.js-action-marker';
-      var selector = entityClass + '[data-id="' + id + '"]' +
-        (locationId ? '[data-location="' + locationId + '"]' : '');
-      var markers = this.$el.find(selector);
-
-      if(markers.length === 0) {
-        console.warn('Unable to highlight the marker(s) ' + type + '/' + id +
-          ' on the map');
-      } else {
-        for(var i = 0, j = markers.length; i < j; i++) {
-          markers[i].classList.add('-active');
-        }
-      }
-    },
-
-    /* Update the markers depending on the entity's id passed as parameter, by
-     * focusing it and bluring the other ones */
-    updateMarkersFocus: function(type, id) {
-      if(!this.isMapInstanciated) {
-        this.queue.push([this.updateMarkersFocus, [ type, id ],
-          2]);
-        return;
-      }
-
-      this.resetMarkersFocus();
-      this.focusOnMarker(type, id);
-    },
-
-    /* Update the map and the markers according to the route triggered by the
-     * router */
-    updateMapFromRoute: function(route) {
-      switch(route) {
-        case 'actor':
-          this.updateMarkersFocus('actors', arguments[1][0]);
-          break;
-
-        case 'action':
-          this.updateMarkersFocus('actions', arguments[1][0]);
-          break;
-
-        default:
-          this.resetMarkersFocus();
-          break;
-      }
-    },
-
-    /* Reduce the opacity of relationships parts of the legend which don't
-     * make sense on specific routes */
-    updateLegendFromRoute: function(route) {
-      switch(route) {
-        case 'actor':
-          this.$actionToActionLegend.toggleClass('-disabled', true);
-          this.$actorToActorLegend.toggleClass('-disabled', false);
-          break;
-
-        case 'action':
-          this.$actionToActionLegend.toggleClass('-disabled', false);
-          this.$actorToActorLegend.toggleClass('-disabled', true);
-          break;
-
-        default:
-          this.$actionToActionLegend.toggleClass('-disabled', false);
-          this.$actorToActorLegend.toggleClass('-disabled', false);
-          break;
-      }
-    },
-
-    /* Call all the methods stored in this.queue in order */
-    applyQueue: function() {
-      /* We sort the queue so that the numbers with the smallest priority number
-       * are executed the first */
-      this.queue = this.queue.sort(function(a, b) {
-        if(a.length < 3 || b.length < 3) {
-          console.warning('Each element of the queue needs a priority number');
-          return -1;
-        }
-        return a[2] - b[2];
-      });
-
-      _.each(this.queue, function(method) {
-        if(!method || method.length < 2 || typeof method[0] !== 'function') {
-          console.warn('Unable to execute a queue\'s method');
-        } else {
-          method[0].apply(this, method[1]);
-        }
-      }, this);
-    },
-
-    /* Toggle the visibility of the relationships on the map (ie the links) and
-     * the switch button
-     * options can be null/undefined or { visible: [boolean] } */
-    toggleRelationshipsVisibility: function(options) {
-      var isVisible = options.visible;
-      /* We toggle the part concerning the relationships from the legend */
-      this.$legend.toggleClass('-reduced', !isVisible);
-      /* We move the zoom buttons according to the legend move */
-      this.$zoomButtons.toggleClass('-slided', !isVisible);
-      /* We toggle the switch button concerning the relationships */
-      this.$relationshipsToggle.prop('checked', isVisible);
-      /* TODO: implementation of the method */
-      console.warn('Feature not yet implemented');
-    },
-
     /* Trigger the visibility of the relationships (ie links) on the map */
     triggerRelationshipsVisibility: function(e) {
       root.app.pubsub.trigger('relationships:visibility',
         { visible: e.currentTarget.checked });
-    },
-
-    /* Move the buttons and the credits aligned with the sidebar */
-    slideButtons: function(options) {
-      this.$buttons.toggleClass('-slided', options.isHidden);
-      this.$credits.toggleClass('-slided', options.isHidden);
-    },
-
-    /* Remove a type of markers if it has been filtered out */
-    onFiltering: function() {
-      var typefiltering = this.router.getQueryParams().types;
-
-      /* If the user ask for both the actors and actions, we don't do anything
-       */
-      if(!typefiltering || typefiltering.length === 2) return;
-
-      /* Otherwise, we remove the entity type which shouldn't appear anymore */
-      var entities = ['actors', 'actions'];
-      this.removeMarkers(_.difference(entities, typefiltering)[0]);
     }
 
   });

--- a/app/assets/javascripts/prototype/views/sidebar/sidebar_action_toolbar_view.js
+++ b/app/assets/javascripts/prototype/views/sidebar/sidebar_action_toolbar_view.js
@@ -19,33 +19,27 @@
       this.router = options.router;
       this.$goBackButton = this.$el.find('.js-back');
       this.setListeners();
+      this.init();
     },
 
     setListeners: function() {
-      this.listenTo(this.router, 'route', this.updateFromRoute);
+      this.listenTo(root.app.pubsub, 'show:actor', this.showGoBackButton);
+      this.listenTo(root.app.pubsub, 'show:action', this.showGoBackButton);
+      this.listenTo(root.app.pubsub, 'click:goBack', this.hideGoBackButton);
     },
 
-    /* According to the route broadcast by the router show or hide options from
-     * the toolbar */
-    updateFromRoute: function(route) {
-      switch(route) {
-        case 'actor':
-          this.showGoBackButton();
-          break;
-
-        case 'action':
-          this.showGoBackButton();
-          break;
-
-        default:
-          this.hideGoBackButton();
-          break;
+    /* Set the initial visibility of the go back button */
+    init: function() {
+      var route = this.router.getCurrentRoute();
+      if(route.name === 'actors' || route.name === 'actions') {
+        this.showGoBackButton();
       }
     },
 
     /* Reset the URL to its original state */
     goBack: function() {
       this.router.navigate('/', { trigger: true });
+      root.app.pubsub.trigger('click:goBack');
     },
 
     showGoBackButton: function() {

--- a/app/assets/javascripts/prototype/views/sidebar/sidebar_action_view.js
+++ b/app/assets/javascripts/prototype/views/sidebar/sidebar_action_view.js
@@ -28,25 +28,25 @@
       this.model = new root.app.Model.actionModel();
       /* The DOM element to receive the Handlbars template */
       this.setListeners();
+
+      this.init();
     },
 
     setListeners: function() {
-      this.listenTo(this.router, 'route', this.toggleVisibilityFromRoute);
-      this.listenTo(this.router, 'route:action', this.fetchDataAndRender);
+      this.listenTo(root.app.pubsub, 'click:goBack', this.hide);
+      this.listenTo(root.app.pubsub, 'show:actor', this.hide);
+      this.listenTo(root.app.pubsub, 'show:action', this.fetchDataAndRender);
       this.listenTo(root.app.pubsub, 'relationships:visibility',
         this.toggleRelationshipsVisibility);
       this.listenTo(root.app.pubsub, 'sync:actionModel', this.populateModelFrom);
       this.listenTo(this.model, 'sync', this.triggerModelSync);
     },
 
-    /* According to the route broadcast by the router show or hide the pane */
-    toggleVisibilityFromRoute: function(route) {
-      if(route === 'action') {
-        /* We don't do anything because we want the view to render before the
-         * content to by slided. The call to this.show() is made in the render
-         * method. */
-      } else {
-        this.hide();
+    /* Initialize the pane state (ie visibility and content) */
+    init: function() {
+      var route = this.router.getCurrentRoute();
+      if(route.name === 'actions') {
+        this.fetchDataAndRender(route.params[0]);
       }
     },
 

--- a/app/assets/javascripts/prototype/views/sidebar/sidebar_actor_view.js
+++ b/app/assets/javascripts/prototype/views/sidebar/sidebar_actor_view.js
@@ -28,25 +28,25 @@
       this.model = new root.app.Model.actorModel();
       /* The DOM element to receive the Handlbars template */
       this.setListeners();
+
+      this.init();
     },
 
     setListeners: function() {
-      this.listenTo(this.router, 'route', this.toggleVisibilityFromRoute);
-      this.listenTo(this.router, 'route:actor', this.fetchDataAndRender);
+      this.listenTo(root.app.pubsub, 'click:goBack', this.hide);
+      this.listenTo(root.app.pubsub, 'show:action', this.hide);
+      this.listenTo(root.app.pubsub, 'show:actor', this.fetchDataAndRender);
       this.listenTo(root.app.pubsub, 'relationships:visibility',
         this.toggleRelationshipsVisibility);
       this.listenTo(root.app.pubsub, 'sync:actorModel', this.populateModelFrom);
       this.listenTo(this.model, 'sync', this.triggerModelSync);
     },
 
-    /* According to the route broadcast by the router show or hide the pane */
-    toggleVisibilityFromRoute: function(route) {
-      if(route === 'actor') {
-        /* We don't do anything because we want the view to render before the
-         * content to by slided. The call to this.show() is made in the render
-         * method. */
-      } else {
-        this.hide();
+    /* Initialize the pane state (ie visibility and content) */
+    init: function() {
+      var route = this.router.getCurrentRoute();
+      if(route.name === 'actors') {
+        this.fetchDataAndRender(route.params[0]);
       }
     },
 
@@ -109,6 +109,7 @@
       /* We finally slide the pane to display the information */
       this.show();
     }
+
   });
 
   /* We extend the view with method to show, hide and toggle the pane */

--- a/app/assets/javascripts/prototype/views/sidebar/sidebar_filters_view.js
+++ b/app/assets/javascripts/prototype/views/sidebar/sidebar_filters_view.js
@@ -40,17 +40,10 @@
     },
 
     setListeners: function() {
-      this.listenTo(this.router, 'route', this.toggleVisibilityFromRoute);
+      this.listenTo(root.app.pubsub, 'show:actor', this.onActorShow);
+      this.listenTo(root.app.pubsub, 'show:action', this.onActionShow);
+      this.listenTo(root.app.pubsub, 'click:goBack', this.onClickGoBack);
       this.listenTo(this.status, 'change', this.applySearch);
-    },
-
-    /* According to the route broadcast by the router show or hide the pane */
-    toggleVisibilityFromRoute: function(route) {
-      if(route !== 'welcome') {
-        this.hide();
-      } else {
-        this.show();
-      }
     },
 
     /* GETTERS */
@@ -198,6 +191,7 @@
         this.checkFilterAllCheckboxes(filterRootElem);
       }
 
+      this.syncFilterHiddenInputWithCheckboxes(filterRootElem);
       this.updateFilterToggleCheckButton(filterRootElem);
       this.updateFilterNotificationBadge(filterRootElem);
       this.updateApplyButtonState();
@@ -215,6 +209,18 @@
       if(!this.isApplyButtonDisabled()) {
         this.applyFilters();
       }
+    },
+
+    onActorShow: function() {
+      this.hide();
+    },
+
+    onActionShow: function() {
+      this.hide();
+    },
+
+    onClickGoBack: function() {
+      this.show();
     },
 
     /* LOGIC */
@@ -417,8 +423,6 @@
      * TODO: remove the console.warn once the form features are all implemented
      */
     applyFilters: function() {
-      console.warn('The feature is only partially implemented');
-
       var inputs = this.getAllInputs();
 
       var field, value, summary = {};

--- a/app/assets/javascripts/prototype/views/sidebar_view.js
+++ b/app/assets/javascripts/prototype/views/sidebar_view.js
@@ -22,15 +22,14 @@
         router: options.router
       });
       this.$toggleSwitch = this.$el.find('.toggleswitch');
-      this.actorsCollection = options.actorsCollection;
       this.setListeners();
     },
 
     setListeners: function() {
       this.listenTo(this.status, 'change:isHidden', this.triggerVisibility);
       this.listenTo(this.tabNavigationView, 'tab:change', this.switchContent);
-      this.listenTo(this.router, 'route:actor', this.show);
-      this.listenTo(this.router, 'route:action', this.show);
+      this.listenTo(root.app.pubsub, 'show:actor', this.show);
+      this.listenTo(root.app.pubsub, 'show:action', this.show);
       this.$toggleSwitch.on('click', this.toggle.bind(this));
     },
 

--- a/app/assets/javascripts/prototype/views/tab_navigation_view.js
+++ b/app/assets/javascripts/prototype/views/tab_navigation_view.js
@@ -14,7 +14,7 @@
     el: document.querySelector('.tab-navigation'),
 
     events: {
-      'click li': 'tabChangeListener'
+      'click li': 'onTabChange'
     },
 
     initialize: function(options) {
@@ -25,17 +25,28 @@
 
     setListeners: function() {
       this.listenTo(this.status, 'change:activeTab', this.triggerTabChange);
-      this.listenTo(this.router, 'route', this.updateActiveTabFromRoute);
+      this.listenTo(root.app.pubsub, 'show:actor', this.onActorShow);
+      this.listenTo(root.app.pubsub, 'show:action', this.onActionShow);
     },
 
-    /* Show the active tab in the DOM and modify the activeTab property of the
-     * status model */
-    tabChangeListener: function(e) {
+    /* EVENTS HANDLERS */
+
+    onActorShow: function() {
+      this.setActiveTab('overall');
+    },
+
+    onActionShow: function() {
+      this.setActiveTab('overall');
+    },
+
+    onTabChange: function(e) {
       e.preventDefault();
       var selectedTab     = e.currentTarget,
           selectedTabName = selectedTab.getAttribute('data-tab');
       this.setActiveTab(selectedTabName);
     },
+
+    /* LOGIC */
 
     /* Switch the active tab to the one passed as argument */
     setActiveTab: function(selectedTabName) {
@@ -60,15 +71,6 @@
         newTab:      this.status.get('activeTab')
       });
     },
-
-    /* Set the active tab depending on the route passed as argument */
-    updateActiveTabFromRoute: function(route) {
-      switch(route) {
-        case 'actor':
-          this.setActiveTab('overall');
-          break;
-      }
-    }
 
   });
 


### PR DESCRIPTION
This is a major PR to address issues related to the communication between views and the event flow. 

Before, the views would be listening to the URL's changes to update themselves but it used to cause issues with the asynchronous nature of the map (which needs to fetch the CartoDB layer and the collections of actors and actions). A queue was implemented to tackle them, but it resulted in a complicated code which still had few cases where it could fail.

Indeed, this PR changes the architecture of the communication. From now on, the views will communicate with a pub/sub mechanism and won't listen to any URL's change. In order to provide them an initial state, they can ask the router for it's current route. As a result, all the asynchronous issues has been solved. Another consequence is that PR #81, which was aimed to solve one of them, shouldn't be considered anymore as it tried to solve the issues, sticking with the old architecture.