### PR TITLE
Feature/front overlapping markers

### DIFF
--- a/app/assets/javascripts/prototype/views/map_view.js
+++ b/app/assets/javascripts/prototype/views/map_view.js
@@ -84,10 +84,7 @@
 
       var marker = locationId ? document.querySelector(selector) :
         document.querySelectorAll(selector);
-      if(locationId && !marker || !locationId && marker.length === 0) {
-        console.warn('Unable to find the marker(s) /' +
-          [ type, id, locationId ].join('/'));
-      }
+
       return marker;
     },
 

--- a/app/assets/javascripts/prototype/views/map_view.js
+++ b/app/assets/javascripts/prototype/views/map_view.js
@@ -447,19 +447,19 @@
       var mapZoom = this.map.getZoom();
       switch(true) {
         case mapZoom <= 9:
-          spiralGap             = 2;
+          spiralGap             = 1;
           spiralInitialDistance = 0;
           spiralAngleFactor     = Math.PI / 3;
           break;
 
         case mapZoom <= 11:
-          spiralGap             = 5;
+          spiralGap             = 2;
           spiralInitialDistance = 2;
           spiralAngleFactor     = Math.PI / 3;
           break;
 
         default:
-          spiralGap             = 10;
+          spiralGap             = 5;
           spiralInitialDistance = 5;
           spiralAngleFactor     = Math.PI / 3;
           break;

--- a/app/assets/javascripts/prototype/views/map_view.js
+++ b/app/assets/javascripts/prototype/views/map_view.js
@@ -574,16 +574,9 @@
       }
     },
 
-    /* Delete all the map's markers or only one type of markers if specified */
-    removeMarkers: function(type) {
-      var selector = '.js-actor-marker, .js-action-marker';
-      if(type) {
-        selector = (type === 'actors') ? selector.split(', ')[0] :
-          selector.split(', ')[1];
-      }
-      /* We actually remove the parent of the marker because leaflet adds a
-       * wrapper */
-      this.$el.find(selector).parent().remove();
+    /* Delete all the map's markers */
+    removeMarkers: function() {
+      this.map.removeLayer(this.markersLayer);
     },
 
     /* Update the markers' size according to the map's zoom level */

--- a/app/assets/javascripts/prototype/views/map_view.js
+++ b/app/assets/javascripts/prototype/views/map_view.js
@@ -438,24 +438,6 @@
       this.markersLayer.addTo(this.map);
     },
 
-    // /* Return a LatLng Leaflet object representing the coordinates of the
-    //  * centroid of a set of markers (passed as arguments) */
-    // _computeCentroidLatLng: function() {
-    //   var markers      = arguments[0],
-    //       markersCount = arguments[0].length,
-    //       centroidLat  = 0,
-    //       centroidLng  = 0;
-    //
-    //   var latLng;
-    //   _.each(markers, function(m) {
-    //     latLng = m.getLatLng();
-    //     centroidLat += latLng.lat;
-    //     centroidLng += latLng.lng;
-    //   });
-    //
-    //   return L.latLng(centroidLat / markersCount, centroidLng / markersCount);
-    // },
-
     /* Compute the position of each marker depending on the position of the
      * other ones. If several markers have the exact same position, we move them
      * along an archimede spiral. Expects the layer of markers. */

--- a/app/assets/javascripts/prototype/views/map_view.js
+++ b/app/assets/javascripts/prototype/views/map_view.js
@@ -478,6 +478,31 @@
         return group.length > 1;
       });
 
+      /* We create an array of all the markers that will be moved */
+      var optimallyPositionedMarkers = _.flatten(_.map(conflictingMarkersGroups,
+        function(conflictingMarkersGroup) {
+        return _.map(conflictingMarkersGroup, function(conflictingMarker) {
+          return conflictingMarker;
+        });
+      }));
+
+      /* We compare the list of all the markers which will be moved with the
+       * previously moved to compute if we need to restore their original
+       * position */
+      var markersToRestorePosition = _.compact(_.map(this.optimallyPositionedMarkers,
+        function(m) {
+        if(!~optimallyPositionedMarkers.indexOf(m)) {
+          return m;
+        }
+      }, this));
+
+      /* We restore the position of markers */
+      _.each(markersToRestorePosition, function(m) {
+        m.setLatLng(m.options.originalLatLng);
+      });
+
+      this.optimallyPositionedMarkers = optimallyPositionedMarkers;
+
       /* This layer contains all the map's elements useful for the user to
        * understand that some markers have been moved from their original
        * positions. It contains lines and a marker at the original position. */

--- a/app/assets/javascripts/prototype/views/map_view.js
+++ b/app/assets/javascripts/prototype/views/map_view.js
@@ -578,34 +578,39 @@
 
         var otherEntity, otherEntityLatLng, latLngs;
         _.each(relations, function(relation) {
-          /* TODO: real main location */
-          otherEntityLatLng = L.latLng(relation.locations[0].lat,
-            relation.locations[0].long);
+          if(!!relation.locations.length) {
+            /* TODO: real main location */
+            otherEntityLatLng = L.latLng(relation.locations[0].lat,
+              relation.locations[0].long);
 
-          /* We also highlight the other entity on the map */
-          otherEntity = this.getMarker(entityType, relation.id,
-            relation.locations[0].id);
+            /* We also highlight the other entity on the map */
+            otherEntity = this.getMarker(entityType, relation.id,
+              relation.locations[0].id);
 
-          /* As the markers can be filtered out, we make sure to only add the
-           * relations with the ones visible on the map */
-          if(!!otherEntity) {
-            if(this.status.get('relationshipsVisible')) {
-              this.highlightMarker(otherEntity);
+            /* As the markers can be filtered out, we make sure to only add the
+             * relations with the ones visible on the map */
+            if(!!otherEntity) {
+              if(this.status.get('relationshipsVisible')) {
+                this.highlightMarker(otherEntity);
+              }
+              /* And we add a special class to it so it can't be hidden with the
+               * toggle button for the relationships */
+              otherEntity.classList.add('js-relation-highlight');
+
+              latLngs = [ entityLatLng, otherEntityLatLng ];
+
+              /* We define the line's options */
+              var options = { className: 'map-line js-line' };
+              if(entityType !== type) options.dashArray = '3, 6';
+              if(!this.status.get('relationshipsVisible')) {
+                options.className += ' -hidden';
+              }
+
+              L.polyline(latLngs, options).addTo(this.map);
             }
-            /* And we add a special class to it so it can't be hidden with the
-             * toggle button for the relationships */
-            otherEntity.classList.add('js-relation-highlight');
-
-            latLngs = [ entityLatLng, otherEntityLatLng ];
-
-            /* We define the line's options */
-            var options = { className: 'map-line js-line' };
-            if(entityType !== type) options.dashArray = '3, 6';
-            if(!this.status.get('relationshipsVisible')) {
-              options.className += ' -hidden';
-            }
-
-            L.polyline(latLngs, options).addTo(this.map);
+          } else {
+            console.warn('Unable to show the relation with /' + type + '/' +
+              relation.id + ' because it doesn\'t have any location');
           }
         }, this);
       }.bind(this);

--- a/app/assets/stylesheets/prototype/components/_map-line.scss
+++ b/app/assets/stylesheets/prototype/components/_map-line.scss
@@ -3,7 +3,6 @@
   stroke-width: 2px;
   stroke-opacity: 1;
 
-  &.-hidden {
-    display: none;
-  }
+  &.-secondary { stroke-opacity: .2; cursor: default; }
+  &.-hidden { display: none; }
 }

--- a/app/assets/stylesheets/prototype/components/_map-marker.scss
+++ b/app/assets/stylesheets/prototype/components/_map-marker.scss
@@ -15,5 +15,11 @@
   &.-action > use:first-of-type { fill: $color-6; }
   &.-action > use:last-of-type { fill: transparent; }
 
+  &.-secondary {
+    background-color: $color-1;
+    border-radius: 100%;
+    cursor: default;
+  }
+
   &.-active > use:last-of-type { stroke: $color-1; stroke-width: 2px; }
 }


### PR DESCRIPTION
This PR addresses a UI issue with the overlapping markers when they have the exact same position. 

Instead of showing them on top of one another, they are moved to a near position and linked to their original position thanks to a lines (see the screenshot). The algorithm computes the new position of the markers depending on the zoom level and position them following the path of Archimedean spiral so we make sure we can add any number of overlapping markers to the map.

![Screenshot of the feature](https://cloud.githubusercontent.com/assets/6073968/12641029/88b5cc18-c5ad-11e5-9b53-652c4626f415.png)

Apart from the main feature, this PR removes a console warning which could be misunderstood and fixes an issue where a popup could be stuck because another marker, linked to it, wouldn't have any location specified.
