### PR TITLE
Allows associating actions to indicators on creating indicators

### DIFF
--- a/app/assets/javascripts/forms.coffee
+++ b/app/assets/javascripts/forms.coffee
@@ -23,6 +23,19 @@ jQuery ->
     event.preventDefault()
     showDatepicker()
 
+  $(document).on 'click', '.add_act_relation_fields', (event) ->
+    time = new Date().getTime()
+    regexp = new RegExp($(this).data('id'), 'g')
+    $(this).before($(this).data('fields').replace(regexp, time))
+    event.preventDefault()
+    current_indicator = $('.current-indicator-wrapper .current-indicator')
+    value = $('#indicator_name').val()
+    current_indicator.text value
+    $('#indicator_name').on 'keyup', (e)->
+      current_indicator.text e.currentTarget.value
+      return
+    showDatepicker()
+
   $(document).on 'click', '.add_location', (event) ->
     $siblings = $(event.currentTarget).siblings('.form-inputs')
     map = $($siblings[$siblings.length - 1]).find('.map-preview')[0]

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -77,7 +77,9 @@ class IndicatorsController < ApplicationController
 
     def set_selection
       @indicator_relation_types = RelationType.order(:title).includes_act_indicator_relations.collect { |rt| [ rt.title, rt.id ] }
-      @categories               = SocioCulturalDomain.order(:name)
+      @categories = SocioCulturalDomain.order(:name)
+      @units = Unit.order(:name)
+      @acts_to_select = Act.order(:name).filter_actives
     end
 
     def set_memberships

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -83,6 +83,11 @@ module RoutesHelper
     common_nested_path(form_name, name, f, association, class_name)
   end
 
+  def add_act_indicator_relation_path(name, f, association, class_name=nil)
+    form_name = 'act_relation_form'
+    common_nested_path(form_name, name, f, association, class_name)
+  end
+
   def add_measurement_path(name, f, association, class_name=nil)
     form_name = 'measurements_form'
     common_nested_path(form_name, name, f, association, class_name)

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -13,6 +13,8 @@ class Indicator < ActiveRecord::Base
   has_and_belongs_to_many :socio_cultural_domains, -> { where(type: 'SocioCulturalDomain') }, class_name: 'Category'
   has_and_belongs_to_many :other_domains,          -> { where(type: 'OtherDomain')         }, class_name: 'Category'
 
+  accepts_nested_attributes_for :act_indicator_relations, allow_destroy: true, reject_if: :act_invalid
+
   before_update :deactivate_dependencies, if: '!active and active_changed?'
 
   validates :name,    presence: true
@@ -56,5 +58,10 @@ class Indicator < ActiveRecord::Base
         end
       end
     end
+
+    def act_invalid(attributes)
+      attributes['act_id'].empty? || attributes['relation_type_id'].empty?
+    end
+
 end
 

--- a/app/views/indicators/_act_relation_form.html.slim
+++ b/app/views/indicators/_act_relation_form.html.slim
@@ -1,0 +1,73 @@
+- preview = !f.object.new_record?
+- if preview
+  .row
+    .column.medium-8.medium-offset-4
+      .relation-preview
+        p.relationtype= f.object.relation_type.try(:title_reverse)
+        p.relationtitle= link_to f.object.act.name, f.object.act
+- else
+  .form-inputs.form-inputs-indicator.form-inputs-relations
+    .row
+      .column.medium-4
+        = f.label t('indicators.current_indicator'), class: 'right inline', disabled: common_form?
+      .column.medium-8.text-left.current-indicator-wrapper
+        - if @indicator.new_record?
+          p.current-indicator.-disabled
+        - else
+          p.current-indicator-edit.-disabled
+            = @indicator.name
+    .row
+      .column.medium-4
+        = f.label :relation_type_id, t('acts.relation_name') + '*', class: 'right inline', disabled: common_form?
+      .column.medium-8
+        = f.input :relation_type_id, collection: @indicator_relation_types, as: :collection_select, label: false, input_html: { class: 'relation_type_id' }, disabled: common_form?
+    .row
+      .column.medium-4
+        = f.label :act_id, t('indicators.act') + '*', class: 'right inline', disabled: common_form?
+      .column.medium-8
+        = f.input :act_id, collection: @acts_to_select, as: :collection_select, label: false, input_html: { class: 'relation_act_id' }, disabled: common_form?
+    .row
+      .column.medium-4
+        = f.label :start_date, class: 'right inline', disabled: common_form?
+      .column.medium-8
+        = f.text_field :start_date, 'data-min-date': Date.new(Date.today.year - 90).at_end_of_year,
+                                      'data-max-date': Date.today,
+                                      class: 'js-datepicker relation_start_date', disabled: common_form?
+    .row
+      .column.medium-4
+        = f.label :end_date, class: 'right inline', disabled: common_form?
+      .column.medium-8
+        = f.text_field :end_date, 'data-min-date': Date.new(Date.today.year - 90).at_end_of_year,
+                                    'data-max-date': Date.today,
+                                    'data-blank-date': true,
+                                    class: 'js-datepicker relation_end_date', disabled: common_form?
+
+    .row
+      .column.medium-4
+        = f.label :deadline, class: 'right inline', disabled: common_form?
+      .column.medium-8
+        = f.text_field :deadline, 'data-min-date': Date.new(Date.today.year - 90).at_end_of_year,
+                                    'data-max-date': Date.new(Date.today.year + 5).at_end_of_year,
+                                    'data-blank-date': true,
+                                    class: 'js-datepicker relation_deadline', disabled: common_form?
+
+    .row
+      .column.medium-4
+        = f.label :target_value, class: 'right inline', disabled: common_form?
+      .column.medium-8
+        = f.input :target_value, input_html: { class: 'relation_target_value' }, label: false, disabled: common_form?
+
+    .row
+      .column.medium-4
+        = f.label :unit_id, class: 'right inline', disabled: common_form?
+      .column.medium-8
+        = f.input :unit_id, collection: @units, as: :collection_select, label: false, input_html: { class: 'relation_unit' }, disabled: common_form?
+
+    - unless common_form?
+      .row
+        .column
+          p.text-right.remove_link
+            / Do not move this fields!
+            = f.hidden_field :user_id, value: current_user.id
+            = f.hidden_field :_destroy
+            = link_to t('relations.delete'), '#', id: "delete-#{f.object.id}", class: 'remove_fields remove_act'

--- a/app/views/indicators/_form.html.slim
+++ b/app/views/indicators/_form.html.slim
@@ -22,4 +22,20 @@
         .column.medium-4
           = form.label :category_ids, class: 'right inline', disabled: common_form?
         .column.medium-8
-          = form.input :category_ids, collection: @categories, as: ((Category.count > 4) ? :select : :check_boxes), label: false, input_html: { multiple: true, class: ((Category.count > 4) ? "js-mselect" : "") }, disabled: common_form?
+          = form.input :category_ids, collection: @categories,
+            as: ((Category.count > 4) ? :select : :check_boxes), label: false,
+            input_html: { multiple: true, class: ((Category.count > 4) ? "js-mselect" : "") },
+            disabled: common_form?
+
+.row
+  .column.medium-8.medium-offset-1
+    .row
+      .column.medium-8.medium-offset-4
+        h2 = t('indicators.link_to_actions')
+    .row
+      = form.fields_for :act_indicator_relations do |rel_form|
+        = render 'act_relation_form', f: rel_form
+      - unless common_form?
+        p.text-right.add-button
+          = add_act_indicator_relation_path t('relations.add_relation'), form,
+            :act_indicator_relations, 'add_act_relation_fields add_indicator'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -406,6 +406,8 @@ en:
     current_indicator: 'Current indicator'
     remove_action: 'Remove action'
     remove_indicator: 'Remove indicator'
+    link_to_actions: 'Link to Actions'
+    act: 'Action'
 
     units:
       units: 'Units'


### PR DESCRIPTION
Follows similar flow as Actors and Actions management.

Except that it:

* Doesnt allow removing relation on editing of an indicator.
* And doesn't allow managing measurements from Indicators management page.