### PR TITLE
Feature/front filters categories

### DIFF
--- a/app/assets/javascripts/prototype/templates/popup_template.hbs
+++ b/app/assets/javascripts/prototype/templates/popup_template.hbs
@@ -4,7 +4,7 @@
 <h1 class="title -tertiary">{{name}}</h1>
 <hr class="delimiter">
 {{#if socio_cultural_domains}}
-  {{{t 'front.socio_cultural_domains'}}}:
+  {{{t 'front.3x5'}}}:
   <ul class="visual-list {{#compare socio_cultural_domains.length ">" 4}}-textual{{/compare}}">
     {{#each socio_cultural_domains}}
       <li class="item" title="{{name}}">
@@ -21,7 +21,7 @@
   </ul>
 {{/if}}
 {{#if other_domains}}
-  {{{t 'front.other_domains'}}}:
+  {{{t 'front.3xX'}}}:
   <ul class="visual-list {{#compare socio_cultural_domains.length ">" 4}}-textual{{/compare}}">
     {{#each other_domains}}
       <li class="item" title="{{name}}">

--- a/app/assets/javascripts/prototype/templates/sidebar/sidebar_action_template.hbs
+++ b/app/assets/javascripts/prototype/templates/sidebar/sidebar_action_template.hbs
@@ -1,7 +1,7 @@
 <div class="content">
   <h1 class="title">{{name}}</h1>
-  <h2 class="title -secondary">{{{t 'front.socio_cultural_domains'}}}</h2>
   {{#if socio_cultural_domains}}
+    <h2 class="title -secondary">{{{t 'front.3x5'}}}</h2>
     <ul class="visual-list">
       {{#each socio_cultural_domains}}
         <li class="item" title="{{name}}">
@@ -17,8 +17,8 @@
       {{/each}}
     </ul>
   {{/if}}
-  <h2 class="title -secondary">{{{t 'front.other_domains'}}}</h2>
   {{#if other_domains}}
+    <h2 class="title -secondary">{{{t 'front.3xX'}}}</h2>
     <ul class="visual-list">
       {{#each other_domains}}
         <li class="item" title="{{name}}">

--- a/app/assets/javascripts/prototype/templates/sidebar/sidebar_actor_template.hbs
+++ b/app/assets/javascripts/prototype/templates/sidebar/sidebar_actor_template.hbs
@@ -1,7 +1,7 @@
 <div class="content">
   <h1 class="title">{{name}}</h1>
-  <h2 class="title -secondary">{{{t 'front.socio_cultural_domains'}}}</h2>
   {{#if socio_cultural_domains}}
+    <h2 class="title -secondary">{{{t 'front.3x5'}}}</h2>
     <ul class="visual-list">
       {{#each socio_cultural_domains}}
         <li class="item" title="{{name}}">
@@ -17,8 +17,8 @@
       {{/each}}
     </ul>
   {{/if}}
-  <h2 class="title -secondary">{{{t 'front.other_domains'}}}</h2>
   {{#if other_domains}}
+    <h2 class="title -secondary">{{{t 'front.3xX'}}}</h2>
     <ul class="visual-list">
       {{#each other_domains}}
         <li class="item" title="{{name}}">

--- a/app/assets/javascripts/prototype/views/map_view.js
+++ b/app/assets/javascripts/prototype/views/map_view.js
@@ -307,7 +307,8 @@
         queryParams.levels && queryParams.levels.length === 0 ||
         queryParams.domains_ids && queryParams.domains_ids.length === 0) {
         console.error('A required parameter hasn\'t been provided');
-        return;
+        var deferred = $.Deferred();
+        return deferred.reject();
       }
 
       var params = {};

--- a/app/assets/javascripts/prototype/views/sidebar/sidebar_filters_view.js
+++ b/app/assets/javascripts/prototype/views/sidebar/sidebar_filters_view.js
@@ -333,9 +333,11 @@
        * account the specificity of the 3x5 and 3xX fields merged into one param
        * domains_ids in the URL */
       queryParams = _.clone(queryParams);
-      queryParams['3x5_ids'] = queryParams.domains_ids;
-      queryParams['3xX_ids'] = queryParams.domains_ids;
-      delete queryParams.domains_ids;
+      if(queryParams.domains_ids) {
+        queryParams['3x5_ids'] = queryParams.domains_ids;
+        queryParams['3xX_ids'] = queryParams.domains_ids;
+        delete queryParams.domains_ids;
+      }
 
       var input;
       _.each(queryParams, function(value, key) {

--- a/app/assets/javascripts/prototype/views/sidebar/sidebar_filters_view.js
+++ b/app/assets/javascripts/prototype/views/sidebar/sidebar_filters_view.js
@@ -471,16 +471,25 @@
     isApplyButtonDisabled: function() {
       var hiddenInputs = this.getAllHiddenInputs();
 
+      /* For the 3x5 and 3xX fields, the validation rule is that at least one
+       * of the set of checkboxes is checked (one of 3x5 or one of 3xX) */
+      var domainsCheckboxesCount = 0;
+
       var filterRootElem, checkedCheckboxesCount;
       for(var i = 0, j = hiddenInputs.length; i < j; i++) {
         filterRootElem = this.getFilterRootElem(hiddenInputs[i]);
         checkedCheckboxesCount =
           this.getFilterCheckedCheckboxes(filterRootElem).length;
 
-        if(checkedCheckboxesCount === 0) return true;
+        if(hiddenInputs[i].name === '3x5_ids' ||
+          hiddenInputs[i].name === '3xX_ids') {
+          domainsCheckboxesCount += checkedCheckboxesCount;
+        } else {
+          if(checkedCheckboxesCount === 0) return true;
+        }
       }
 
-      return false;
+      return domainsCheckboxesCount === 0;
     },
 
     /* Disable or enable the apply button depending if there's a filter with all

--- a/app/assets/stylesheets/prototype/components/_message.scss
+++ b/app/assets/stylesheets/prototype/components/_message.scss
@@ -6,6 +6,7 @@
   line-height: 17px;
 
   &.-error {
+    color: $color-1;
     padding: 12px 12px 12px 37px;
     background: url(asset_path("message_alert.png")) top 10px left 10px / 17px no-repeat $color-17;
   }

--- a/app/controllers/prototype_controller.rb
+++ b/app/controllers/prototype_controller.rb
@@ -2,7 +2,8 @@ class PrototypeController < ApplicationController
   layout 'prototype'
 
   def index
-    @domains    = Category.where(type: ['SocioCulturalDomain', 'OtherDomain']).order(:name)
+    @socio_cultural_domains = Category.where(type: ['SocioCulturalDomain']).order(:name)
+    @other_domains = Category.where(type: ['OtherDomain']).order(:name)
     @start_date = min_start_date
     @end_date   = max_end_date
     gon.min_date = @start_date

--- a/app/views/layouts/prototype.html.slim
+++ b/app/views/layouts/prototype.html.slim
@@ -147,17 +147,38 @@ html lang="en"
                           | Micro
                   li.section
                     input#filtersSection2.toggle-button type="checkbox" value="" style="display: none;"
-                    label#filtersTab2.title for="filtersSection2" aria-label="toggle domain filter" aria-controls="filtersPanel2"
-                      = t('front.categories')
+                    label#filtersTab2.title for="filtersSection2" aria-label="toggle 3x5 filter" aria-controls="filtersPanel2"
+                      = t('front.3x5')
                       span.notification-badge.js-badge = t('front.all')
                     #filtersPanel2.content.js-content aria-hidden="true"
-                      select.js-input name="domains_ids" disabled="disabled" multiple="multiple" style="display:none;"
-                        -@domains.each do |domain|
-                          option value="#{domain.id}" selected="selected" = domain.name
-                      -@domains.each do |domain|
+                      select.js-input name="3x5_ids" disabled="disabled" multiple="multiple" style="display:none;"
+                        -@socio_cultural_domains.each do |socio_cultural_domain|
+                          option value="#{socio_cultural_domain.id}" selected="selected" = socio_cultural_domain.name
+                      -@socio_cultural_domains.each do |socio_cultural_domain|
                         .form-input
-                          input.input.-checkbox id="domains#{domain.id}" type="checkbox" value="#{domain.id}" checked="checked"
-                          label.label for="domains#{domain.id}" = domain.name
+                          input.input.-checkbox id="domains#{socio_cultural_domain.id}" type="checkbox" value="#{socio_cultural_domain.id}" checked="checked"
+                          label.label for="domains#{socio_cultural_domain.id}" = socio_cultural_domain.name
+                      button.button.-outlined.-small._floatright.js-check-all type="button"
+                        svg.icon.-marginright width="10" height="10"
+                          use xlink:href="#checkIcon" x="0" y="0"
+                        span = t('front.check_all')
+                      button.button.-outlined.-small.js-uncheck-all type="button"
+                        svg.icon.-marginright width="10" height="10"
+                          use xlink:href="#uncheckIcon" x="0" y="0"
+                        span = t('front.uncheck_all')
+                  li.section
+                    input#filtersSection3.toggle-button type="checkbox" value="" style="display: none;"
+                    label#filtersTab2.title for="filtersSection3" aria-label="toggle 3xX filter" aria-controls="filtersPanel3"
+                      = t('front.3xX')
+                      span.notification-badge.js-badge = t('front.all')
+                    #filtersPanel3.content.js-content aria-hidden="true"
+                      select.js-input name="3xX_ids" disabled="disabled" multiple="multiple" style="display:none;"
+                        -@other_domains.each do |other_domain|
+                          option value="#{other_domain.id}" selected="selected" = other_domain.name
+                      -@other_domains.each do |other_domain|
+                        .form-input
+                          input.input.-checkbox id="domains#{other_domain.id}" type="checkbox" value="#{other_domain.id}" checked="checked"
+                          label.label for="domains#{other_domain.id}" = other_domain.name
                       button.button.-outlined.-small._floatright.js-check-all type="button"
                         svg.icon.-marginright width="10" height="10"
                           use xlink:href="#checkIcon" x="0" y="0"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -439,7 +439,8 @@ en:
     only_actors: Only actors
     only_actions: Only actions
     levels: Levels
-    categories: Categories
+    3x5: 3x5
+    3xX: 3xX
     start_date: Start date
     end_date: End date
     want_save_search: Do you want to save this search?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -449,7 +449,7 @@ en:
     all: All
     check_all: Check all
     uncheck_all: Uncheck all
-    cant_apply_search_0_check: You can not apply the search if a filter hasn't any selected option
+    cant_apply_search_0_check: To perform a search, you must check at least one checkbox for each filter, except for 3x5 and 3xX where you can leave one of them with 0 check 
     loading: Loading
     to_actors: "To Actors:"
     to_actions: "To Actions:"


### PR DESCRIPTION
This PR splits the filter "categories" into "3x5" and "3xX" making sure that the URL parameter stays `domains_ids`. Also, the name changes have been reflected through all the front-office interface (popups and sidebar).

@simaob, can you confirm we want just those names as titles in the sidebar and within the popups?