### PR TITLE
Fixes an issue where a console error would appear on Firefox

### DIFF
--- a/app/assets/javascripts/prototype/helpers/utils.js
+++ b/app/assets/javascripts/prototype/helpers/utils.js
@@ -18,7 +18,7 @@
     getClosestParent: function(el, selector) {
       var res = null;
       var currentElement = el;
-      while(currentElement !== document) {
+      while(currentElement !== document && currentElement !== null) {
         if(this.matches(currentElement, selector)) {
           res = currentElement;
           break;

--- a/app/assets/javascripts/prototype/views/map/map_markers.js
+++ b/app/assets/javascripts/prototype/views/map/map_markers.js
@@ -131,7 +131,7 @@
 
     onPopupBlur: function(e, marker) {
       /* We close the popup when leaving it and not entering a marker */
-      if(!root.app.Helper.utils.getClosestParent(e.originalEvent.toElement,
+      if(!root.app.Helper.utils.getClosestParent(e.relatedTarget,
         '.leaflet-marker-icon')) {
         marker.closePopup();
       }


### PR DESCRIPTION
This PR fixes an issue where the popups would stay opened on Firefox because a Javascript error would be triggered.

NOTE: when the user moves the cursor out of the opened popup and in direction of a marker (really) close to it, it could stay opened. Solving this issue would require a lot of work so I think we should leave it  as a known bug for now.