### PR TITLE
fixes error with the alert boxes thrown by the foundation js

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -7,6 +7,7 @@
 //= require favourites
 //= require foundation
 //= require select2
+//= require modernizr
 
 /* Dynamically filter the forms that are shown for the actors and actions pages
  */


### PR DESCRIPTION
"Uncaught ReferenceError: Modernizr is not defined." 
When trying to close a alert box (the ones that appear when logging in / out).