### PR TITLE
Includes relation type names in GET /api/relations

### DIFF
--- a/api/app/serializers/relation_array_serializer.rb
+++ b/api/app/serializers/relation_array_serializer.rb
@@ -7,6 +7,13 @@ class RelationArraySerializer < BaseSerializer
   def attributes
     data = super
     data['type']           = type
+    titles = [
+      object.relation_type.title,
+      object.relation_type.title_reverse
+    ]
+    data['relation_type_text'] = titles.join(" - ")
+    # make slug in format text-other-text
+    data['relation_type_slug'] = titles.join("-").downcase.gsub(" ", "-")
     data['start_location'] = parent_location
     data['end_location']   = child_location
     data


### PR DESCRIPTION
Includes two new fields:

* relation-type-text: e.g.: Contains - Belongs to
* relation-type-slug: e.g.: contains-belongs-to

You might need to clear your cache to be able to see this.