### PR TITLE
Fix/backoffice relations

### DIFF
--- a/app/assets/javascripts/forms.coffee
+++ b/app/assets/javascripts/forms.coffee
@@ -45,7 +45,7 @@ jQuery ->
 
   cloneCount = 1
 
-  $(document).on 'click', '.add_actors_fields, .add_actions_fields, .add_indicators_fields', (event) ->
+  $(document).on 'click', '.add_actors_fields, .add_actions_fields', (event) ->
     time       = new Date().getTime()
     regexp     = new RegExp($(this).data('id'), 'g')
 

--- a/app/assets/stylesheets/components/_relation-preview.scss
+++ b/app/assets/stylesheets/components/_relation-preview.scss
@@ -4,10 +4,6 @@
   border-bottom: 1px solid $color-13;
   margin-top: -1px;
 
-  &.-first-preview {
-    border-top: none;
-  }
-
   >.relationtype {
     margin-bottom: 8px;
     @include font(helvetica, xxsmall, light, 1);

--- a/app/controllers/acts_controller.rb
+++ b/app/controllers/acts_controller.rb
@@ -131,7 +131,7 @@ class ActsController < ApplicationController
       @all_indicators_to_select = Indicator.order(:name).filter_actives
 
       @units                  = Unit.order(:name)
-      @actor_relation_types           = RelationType.order(:title).includes_actor_act_relations.collect     { |rt| [ rt.title, rt.id ]         }
+      @actor_relation_types           = RelationType.order(:title).includes_actor_act_relations.collect     { |rt| [ rt.title_reverse, rt.id ] }
       @action_relation_types          = RelationType.order(:title).includes_act_relations.collect           { |rt| [ rt.title, rt.id ]         }
       @action_relation_children_types = RelationType.order(:title).includes_act_relations.collect           { |rt| [ rt.title_reverse, rt.id ] }
       @indicator_relation_types       = RelationType.order(:title).includes_act_indicator_relations.collect { |rt| [ rt.title, rt.id ]         }

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -76,7 +76,7 @@ class IndicatorsController < ApplicationController
     end
 
     def set_selection
-      @indicator_relation_types = RelationType.order(:title).includes_act_indicator_relations.collect { |rt| [ rt.title, rt.id ] }
+      @indicator_relation_types = RelationType.order(:title).includes_act_indicator_relations.collect { |rt| [ rt.title_reverse, rt.id ] }
       @categories = SocioCulturalDomain.order(:name)
       @units = Unit.order(:name)
       @acts_to_select = Act.exclude_related_actions_for_indicator(@indicator)

--- a/app/views/acts/_actor_relation_form.html.slim
+++ b/app/views/acts/_actor_relation_form.html.slim
@@ -3,8 +3,8 @@
 - if preview
   .row
     .column.medium-8.medium-offset-4
-      .relation-preview class=('-first-preview' if relation_index < 1)
-        p.relationtype= f.object.relation_type.try(:title)
+      .relation-preview
+        p.relationtype= f.object.relation_type.try(:title_reverse)
         p.relationtitle= link_to f.object.actor.name, actor_path(f.object.actor)
         p.relationbuttons
           = link_to t('relations.view'), "#", id: "actors-relation-#{f.object.id}",
@@ -12,6 +12,7 @@
           - unless common_form?
             = link_to t('relations.remove_relation'), "#", class: "remove_fields_preview", 'data-delete-pair': "delete-#{f.object.id}"
 .form-inputs.form-inputs-actor.form-inputs-relations.action-actor-relation class=[('hide' if preview), ('-first-form' if relation_index < 1)] id=("expanded-actors-relation-#{f.object.id}" if preview)
+
   .row
     .column.medium-4
       = f.label t('acts.current_action'), class: 'right inline', disabled: common_form?

--- a/app/views/acts/_form.html.slim
+++ b/app/views/acts/_form.html.slim
@@ -133,4 +133,4 @@
             - unless common_form?
               p.text-right.add-button
                 / Add more css classes to 'add_indicator', sample 'add_indicator your_class_name'
-                = add_indicator_relation_path t('relations.add_relation'), form, :act_indicator_relations, 'add_fields add_indicator add_indicators_fields'
+                = add_indicator_relation_path t('relations.add_relation'), form, :act_indicator_relations, 'add_fields add_indicators_fields'


### PR DESCRIPTION
- fixes relations error in indicators–actions and in actions–actors

- removes css declaration for top-borders on first relations because the .-first-preview class is not assigned correctly always (TBD: determine which relation is the first one?)