### PR TITLE
Fix/backoffice relations

### DIFF
--- a/app/assets/javascripts/forms.coffee
+++ b/app/assets/javascripts/forms.coffee
@@ -45,7 +45,7 @@ jQuery ->
 
   cloneCount = 1
 
-  $(document).on 'click', '.add_actors_fields, .add_actions_fields, .add_indicators_fields', (event) ->
+  $(document).on 'click', '.add_actors_fields, .add_actions_fields', (event) ->
     time       = new Date().getTime()
     regexp     = new RegExp($(this).data('id'), 'g')
 

--- a/app/assets/stylesheets/components/_relation-preview.scss
+++ b/app/assets/stylesheets/components/_relation-preview.scss
@@ -4,10 +4,6 @@
   border-bottom: 1px solid $color-13;
   margin-top: -1px;
 
-  &.-first-preview {
-    border-top: none;
-  }
-
   >.relationtype {
     margin-bottom: 8px;
     @include font(helvetica, xxsmall, light, 1);

--- a/app/controllers/acts_controller.rb
+++ b/app/controllers/acts_controller.rb
@@ -131,7 +131,7 @@ class ActsController < ApplicationController
       @all_indicators_to_select = Indicator.order(:name).filter_actives
 
       @units                  = Unit.order(:name)
-      @actor_relation_types           = RelationType.order(:title).includes_actor_act_relations.collect     { |rt| [ rt.title, rt.id ]         }
+      @actor_relation_types           = RelationType.order(:title).includes_actor_act_relations.collect     { |rt| [ rt.title_reverse, rt.id ] }
       @action_relation_types          = RelationType.order(:title).includes_act_relations.collect           { |rt| [ rt.title, rt.id ]         }
       @action_relation_children_types = RelationType.order(:title).includes_act_relations.collect           { |rt| [ rt.title_reverse, rt.id ] }
       @indicator_relation_types       = RelationType.order(:title).includes_act_indicator_relations.collect { |rt| [ rt.title, rt.id ]         }

--- a/app/controllers/indicators_controller.rb
+++ b/app/controllers/indicators_controller.rb
@@ -76,7 +76,7 @@ class IndicatorsController < ApplicationController
     end
 
     def set_selection
-      @indicator_relation_types = RelationType.order(:title).includes_act_indicator_relations.collect { |rt| [ rt.title, rt.id ] }
+      @indicator_relation_types = RelationType.order(:title).includes_act_indicator_relations.collect { |rt| [ rt.title_reverse, rt.id ] }
       @categories = SocioCulturalDomain.order(:name)
       @units = Unit.order(:name)
       @acts_to_select = Act.exclude_related_actions_for_indicator(@indicator)

--- a/app/views/actors/_action_relation_form.html.slim
+++ b/app/views/actors/_action_relation_form.html.slim
@@ -24,7 +24,10 @@
     .column.medium-4
       = f.label :relation_type_id, "* " + t('actors.relation_name'), class: 'right inline', disabled: common_form?
     .column.medium-8
-      = f.input :relation_type_id, collection: @action_relation_types, as: :collection_select, label: false, input_html: { class: 'chosen-select relation_type_id' }, disabled: common_form?
+      = f.input :relation_type_id, collection: @action_relation_types,
+        as: :collection_select, label: false,
+        input_html: { class: 'chosen-select relation_type_id' },
+        disabled: common_form?
   .row
     .column.medium-4
       = f.label :act_id, "* " + t('acts.act'), class: 'right inline', disabled: common_form?

--- a/app/views/acts/_actor_relation_form.html.slim
+++ b/app/views/acts/_actor_relation_form.html.slim
@@ -3,8 +3,8 @@
 - if preview
   .row
     .column.medium-8.medium-offset-4
-      .relation-preview class=('-first-preview' if relation_index < 1)
-        p.relationtype= f.object.relation_type.try(:title)
+      .relation-preview
+        p.relationtype= f.object.relation_type.try(:title_reverse)
         p.relationtitle= link_to f.object.actor.name, actor_path(f.object.actor)
         p.relationbuttons
           = link_to t('relations.view'), "#", id: "actors-relation-#{f.object.id}",
@@ -12,6 +12,7 @@
           - unless common_form?
             = link_to t('relations.remove_relation'), "#", class: "remove_fields_preview", 'data-delete-pair': "delete-#{f.object.id}"
 .form-inputs.form-inputs-actor.form-inputs-relations.action-actor-relation class=[('hide' if preview), ('-first-form' if relation_index < 1)] id=("expanded-actors-relation-#{f.object.id}" if preview)
+
   .row
     .column.medium-4
       = f.label t('acts.current_action'), class: 'right inline', disabled: common_form?

--- a/app/views/acts/_actor_relation_form.html.slim
+++ b/app/views/acts/_actor_relation_form.html.slim
@@ -10,7 +10,9 @@
           = link_to t('relations.view'), "#", id: "actors-relation-#{f.object.id}",
             class: "view-relation", 'data-relation-type': "action-actor-relation"
           - unless common_form?
-            = link_to t('relations.remove_relation'), "#", class: "remove_fields_preview", 'data-delete-pair': "delete-#{f.object.id}"
+            = link_to t('relations.remove_relation'), "#",
+              class: "remove_fields_preview",
+              'data-delete-pair': "delete-#{f.object.id}"
 .form-inputs.form-inputs-actor.form-inputs-relations.action-actor-relation class=[('hide' if preview), ('-first-form' if relation_index < 1)] id=("expanded-actors-relation-#{f.object.id}" if preview)
 
   .row
@@ -24,14 +26,23 @@
           = @act.name
   .row
     .column.medium-4
-      = f.label :relation_type_id, "* " + t('acts.current_action'), class: 'right inline', disabled: common_form?
+      = f.label :relation_type_id, "* " + t('acts.current_action'),
+        class: 'right inline', disabled: common_form?
     .column.medium-8
-      = f.input :relation_type_id, collection: @actor_relation_types, as: :collection_select, label: false, input_html: { class: 'chosen-select relation_type_id' }, disabled: common_form?
+      = f.input :relation_type_id, collection: @actor_relation_types,
+        as: :collection_select, label: false,
+        input_html: { class: 'chosen-select relation_type_id' },
+        disabled: common_form?
   .row
     .column.medium-4
-      = f.label :actor_id, "* " + t('actors.actor'), class: 'right inline', disabled: common_form?
+      = f.label :actor_id, "* " + t('actors.actor'), class: 'right inline',
+        disabled: common_form?
     .column.medium-8
-      = f.input :actor_id, collection: preview ? @all_actors_to_select : @actors_to_select, as: :collection_select, label: false, input_html: { multiple: false, class: 'chosen-select collection_select relation_actor_id' }, disabled: common_form?
+      = f.input :actor_id, collection: preview ? @all_actors_to_select : @actors_to_select,
+        as: :collection_select, label: false,
+        input_html: { multiple: false,
+        class: 'chosen-select collection_select relation_actor_id' },
+        disabled: common_form?
   .row
     .column.medium-4
       = f.label :start_date, class: 'right inline', disabled: common_form?
@@ -44,9 +55,10 @@
       = f.label :end_date, class: 'right inline', disabled: common_form?
     .column.medium-8
       = f.text_field :end_date, 'data-min-date': Date.new(Date.today.year - 90).at_end_of_year,
-                                  'data-max-date': Date.today,
-                                  'data-blank-date': true,
-                                  class: 'js-datepicker relation_end_date', disabled: common_form?
+        'data-max-date': Date.today,
+        'data-blank-date': true,
+        class: 'js-datepicker relation_end_date',
+        disabled: common_form?
       = f.error :end_date, id: 'user_name_error'
 
   - unless common_form?
@@ -56,4 +68,5 @@
           / Do not move this fields!
           = f.hidden_field :user_id, value: current_user.id
           = f.hidden_field :_destroy
-          = link_to t('relations.remove_relation'), '#', id: "delete-#{f.object.id}", class: 'remove_fields'
+          = link_to t('relations.remove_relation'), '#',
+            id: "delete-#{f.object.id}", class: 'remove_fields'

--- a/app/views/acts/_form.html.slim
+++ b/app/views/acts/_form.html.slim
@@ -133,4 +133,4 @@
             - unless common_form?
               p.text-right.add-button
                 / Add more css classes to 'add_indicator', sample 'add_indicator your_class_name'
-                = add_indicator_relation_path t('relations.add_relation'), form, :act_indicator_relations, 'add_fields add_indicator add_indicators_fields'
+                = add_indicator_relation_path t('relations.add_relation'), form, :act_indicator_relations, 'add_fields add_indicators_fields'

--- a/features/acts.feature
+++ b/features/acts.feature
@@ -222,7 +222,7 @@ I want to manage an act
     When I go to the edit act page for "First one"
     And I click on hidden ".add_actor" on "#actor_relation_form" within ".tabs-content"
     And I select from the following hidden field ".relation_actor_id" with "Person one"
-    And I select from the following hidden field ".relation_type_id" with "implements"
+    And I select from the following hidden field ".relation_type_id" with "implemented by"
     When I fill in the following field ".relation_start_date" with "1990-03-10"
     When I fill in the following field ".relation_end_date" with "2010-03-10"
     And I press "Update"
@@ -260,7 +260,7 @@ I want to manage an act
     And act_indicator_relation_types
     When I go to the edit act page for "First one"
     And I click on overlapping ".indicator_relations"
-    And I click on hidden ".add_indicator" on "#indicator_relation_form" within ".tabs-content"
+    And I click on hidden ".add_indicators_fields" on "#indicator_relation_form" within ".tabs-content"
     And I select from the following hidden field ".relation_indicator_id" with "Indicator one"
     And I select from the following field ".relation_type_id" with "contains"
     When I fill in the following field ".relation_start_date" with "1990-03-10"
@@ -282,7 +282,7 @@ I want to manage an act
     And action with indicator relations
     And indicator
     When I go to the edit act page for "Action with indicator"
-    And I click on hidden ".add_indicator" on "#indicator_relation_form" within ".tabs-content"
+    And I click on hidden ".add_indicators_fields" on "#indicator_relation_form" within ".tabs-content"
     And I select from the following hidden field ".relation_indicator_id" with "Indicator one"
     Then I should not be able to select from the following field ".relation_indicator_id" with "Indicator one with relation"
 

--- a/features/indicator.feature
+++ b/features/indicator.feature
@@ -102,7 +102,7 @@ I want to manage an indicator
      When I go to the edit indicator page for "Indicator one"
      And I click on overlapping ".add_action"
      And I select from the following hidden field ".relation_act_id" with "First act by admin" within ".indicator_act_indicator_relations_act_id"
-     And I select from the following field ".relation_type_id" with "contains"
+     And I select from the following field ".relation_type_id" with "belongs to"
      When I fill in the following field ".relation_start_date" with "1990-03-10"
      When I fill in the following field ".relation_end_date" with "2010-03-10"
      And I press "Update"


### PR DESCRIPTION
- fixes relations errors in indicator–action and action–actor
- indicators: renames a class and removes a class that was causing double-form-creation in forms.coffee 