### PR TITLE
Feature/front relationships graph changes

### DIFF
--- a/app/assets/javascripts/prototype/views/map/map_graph.js
+++ b/app/assets/javascripts/prototype/views/map/map_graph.js
@@ -41,7 +41,18 @@
     render: function() {
       var relations = this.collection.toJSON();
 
-      var startLatLng, endLatLng, colorClass;
+      var relationTypes = _.keys(_.groupBy(relations, function(relation) {
+        return relation.relation_type_slug;
+      }));
+
+      var relationColors = this.getColorScale(relationTypes.length);
+
+      var relationTypeToColor = {};
+      for(var i = 0, j = relationTypes.length; i < j; i++) {
+        relationTypeToColor[relationTypes[i]] = relationColors[i];
+      }
+
+      var startLatLng, endLatLng, line;
       this.relationsLayer = L.layerGroup(_.compact(_.map(relations,
         function(relation) {
         /* We make sure we have the start and end locations */
@@ -55,21 +66,13 @@
         endLatLng = L.latLng(relation.end_location.lat,
           relation.end_location.long);
 
-        switch(relation.type) {
-          case 'Actor-Actor':
-            colorClass = '-actors';
-            break;
-          case 'Action-Action':
-            colorClass = '-actions';
-            break;
-          default:
-            colorClass = '-mixed';
-            break;
-        }
+        line = L.polyline([startLatLng, endLatLng]);
 
-        return L.polyline([startLatLng, endLatLng], {
-          className: 'map-line ' + colorClass
-        });
+        line.options.color   = relationTypeToColor[relation.relation_type_slug];
+        line.options.weight  = 2;
+        line.options.opacity = 1;
+
+        return line;
       })));
     },
 
@@ -94,6 +97,72 @@
           this.map.removeLayer(this.relationsLayer);
         }
       }
+    },
+
+    /* Return colorCount different CSS HSL colors by making variation of the
+     * hue, and avoiding a large spectrum of the blue one (to avoid conflicts
+     * with the basemap) and a small portion of the red and green so we don't
+     * have too similar colors. The colors grey and red will be always outputed:
+     * the first because it can't be obtained from a hue variation and the
+     * second because of the nature of the algorithm. The saturation is set at
+     * 100% and lightness at 40% to have colors darker then their hues. */
+
+    /* Return colorCount different HSL colors by making variations of the hue,
+     * saturation and lightness (HSL) according to the parameters set by the
+     * user within the method. The hue range can be restricted to some portions
+     * of it, and the saturation and lightness can be fixed or computed from the
+     * hue, the color index number or any other algorithm. Moreover, some colors
+     * can be set by default so they will always be returned.
+     * NOTE: the current configuration removes the blue, a part of the green and
+     * the red right hand part of the hue range to avoid collision with the
+     * basemap color and avoiding having to many similar green and red colors.
+     * Also, the lightness varies between two consecutive values to make sure
+     * two colors with a similar hue will be visually different. */
+    getColorScale: function(colorCount) {
+      /* We first define the parameters of the algorithm:
+       *  - hueRange is the range where the hues are extracted from
+       *  - saturation can be a fixed value or a function to which the hue and
+       *    the color index will be passed
+       *  - lightness can be passed the same values as saturation
+       *  - colors is an array of colors that will always be returned (for
+       *    example colors that can't be obtained by just changing the hue like
+       *    black and white) */
+      var hueRange   = [ [ 0, 80 ], [ 95, 120 ], [ 150, 210 ], [ 270, 320 ] ],
+          saturation = 100,
+          lightness  = function(hue, index) { return index % 2 ? 70 : 55; },
+          colors     = [ 'hsl(0, 0%, 70%)' ];
+
+      /* In case we're asked fewer colors than the ones defined by default, we
+       * directly use them */
+      if(colorCount <= colors.length) return colors.slice(0, colorCount + 1);
+
+      /* We compute the length of the virtual hue range by summing each
+       * individual range */
+      var hueExtent = hueRange.reduce(function(sum, range) {
+        return sum + range[1] - range[0];
+      }, 0);
+
+      /* We compute the step between each color using our virtual scale */
+      var hueStep = ~~ (hueExtent / colorCount);
+
+      var hue;
+      for(var i = 0, j = colorCount - colors.length; i < j; i++) {
+        hue = i * hueStep;
+
+        /* We now need to make the conversion from the hue virtual scale to the
+         * real one to retrieve the final value */
+        for(var k = 0, l = hueRange.length; k < l; k++) {
+          if(hue > hueRange[k][1]) hue += hueRange[k + 1][0] - hueRange[k][1];
+        }
+
+        /* Now we have the hue, we compute the saturation and lightness */
+        if(typeof saturation === 'function') saturation = saturation(hue, i);
+        if(typeof lightness  === 'function') lightness  = lightness (hue, i);
+
+        colors.push('hsl(' + hue + ', ' + saturation + '%, ' + lightness + '%)');
+      }
+
+      return colors;
     }
 
   });

--- a/app/assets/javascripts/prototype/views/map/map_legend.js
+++ b/app/assets/javascripts/prototype/views/map/map_legend.js
@@ -21,6 +21,8 @@
       this.$actorToActionLegend = this.$el.find('.js-actor-to-action');
       this.$actorToActorLegend = this.$el.find('.js-actor-to-actor');
       this.$actionToActionLegend = this.$el.find('.js-action-to-action');
+      this.$standardLegend = this.$el.find('.js-standard-legend');
+      this.$alternativeLegend = this.$el.find('.js-alternative-legend');
 
       this.setListeners();
     },
@@ -37,29 +39,27 @@
     // },
 
     toggleLegendState: function() {
-      /* We update the action to action icon */
-      this.$actionToActionLegend.find('svg')[0].classList.toggle('-actions',
-        this.status.get('graphVisible'));
-      this.$actionToActionLegend.find('svg')[0].classList.toggle('-monochrome',
-        !this.status.get('graphVisible'));
+      if(!this.status.get('graphVisible')) {
+        this.$alternativeLegend.addClass('-hidden');
+        this.$standardLegend.removeClass('-hidden');
+      }
+    },
 
-      /* We update the actor to actor icon */
-      this.$actorToActorLegend.find('svg')[0].classList.toggle('-actors',
-        this.status.get('graphVisible'));
-      this.$actorToActorLegend.find('svg')[0].classList.toggle('-monochrome',
-        !this.status.get('graphVisible'));
+    showAlternativeLegend: function(options) {
+      var html = '<ul>';
+      html += '<li class="title">' + I18n.translate('front.relationships') +
+        '</li>';
 
-      /* We update the actor to action icon */
-      this.$actorToActionLegend.find('svg')[0].classList.toggle('-mixed',
-        this.status.get('graphVisible'));
-      this.$actorToActionLegend.find('svg')[0].classList.toggle('-monochrome',
-        !this.status.get('graphVisible'));
-      this.$actorToActionLegend.find('svg > use')[0].setAttribute('xlink:href',
-        this.status.get('graphVisible') ? '#actorToActorIcon' :
-        '#actorToActionIcon');
+      _.map(options, function(color, title) {
+        html += '<li><svg class="icon -large">' +
+          '<use xlink:href="#actorToActorIcon" x="0" y="6" stroke="' +
+          color + '"/></svg><span class="label">' + title + '</span></li>';
+      });
 
-      this.el.classList.toggle('-reduced',
-        this.status.get('graphVisible'));
+      html += '</ul>';
+
+      this.$alternativeLegend.html(html).removeClass('-hidden');
+      this.$standardLegend.addClass('-hidden');
     },
 
     /* Dynamically hide a part of the relations depending on the active marker

--- a/app/assets/javascripts/prototype/views/map/map_zoom_buttons.js
+++ b/app/assets/javascripts/prototype/views/map/map_zoom_buttons.js
@@ -21,32 +21,12 @@
       this.status = new Status();
 
       this.zoomToFitButton = document.querySelector('.js-zoom-to-fit');
-
-      this.setListeners();
-    },
-
-    setListeners: function() {
-      this.listenTo(this.status, 'change:graphVisible',
-        this.toggleButtonsPosition);
     },
 
     onZoomToFit: function(e) {
       if(!this.zoomToFitButton.classList.contains('-disabled')) {
         this.trigger('click:zoomToFit');
       }
-    },
-
-    /* Reduce the visible portion of the legend or not depending on if the
-     * relations are visible on the map */
-    toggleButtonsPosition: function() {
-      if(!this.zoomButtons) {
-        this.zoomButtons = this.el.querySelector('.leaflet-control-zoom');
-      }
-
-      this.zoomButtons.classList.toggle('-slided',
-        this.status.get('graphVisible'));
-      this.zoomToFitButton.classList.toggle('-slided',
-        this.status.get('graphVisible'));
     },
 
     /* Enable the button zoom to fit */

--- a/app/assets/javascripts/prototype/views/map_view.js
+++ b/app/assets/javascripts/prototype/views/map_view.js
@@ -81,6 +81,9 @@
       this.listenTo(this.mapZoomButtonsView, 'click:zoomToFit',
         this.onZoomToFitButtonClick);
 
+      this.listenTo(this.mapGraphView, 'update:legend',
+        this.onGraphLegendUpdate);
+
       this.listenTo(this.actorModel, 'sync', this.onActorModelSync);
       this.listenTo(this.actionModel, 'sync', this.onActionModelSync);
 
@@ -303,6 +306,10 @@
       if(this.markersToFit !== null) {
         this.mapMapView.zoomToFit(this.markersToFit);
       }
+    },
+
+    onGraphLegendUpdate: function(options) {
+      this.mapLegendView.showAlternativeLegend(options);
     },
 
     /* Fetch only the collections that are not filtered out and return a

--- a/app/assets/stylesheets/prototype/components/_map-line.scss
+++ b/app/assets/stylesheets/prototype/components/_map-line.scss
@@ -5,7 +5,4 @@
 
   &.-secondary { stroke-opacity: .2; cursor: default; }
   &.-sensitive { stroke-width: 10px; stroke-opacity: 0; }
-  &.-actors  { stroke: $color-6;  }
-  &.-actions { stroke: $color-7;  }
-  &.-mixed   { stroke: $color-19; }
 }

--- a/app/assets/stylesheets/prototype/layouts/_l-map.scss
+++ b/app/assets/stylesheets/prototype/layouts/_l-map.scss
@@ -20,62 +20,120 @@
     position: absolute;
     bottom: 0;
     left: 0;
-    display: flex;
-    justify-content: space-between;
-    flex-wrap: wrap;
     width: 180px;
     background-color: $color-1;
     padding: 15px 22px 0 3px;
-    transform: translateY(0);
-    transition: transform .4s;
 
-    &.-reduced { transform: translateY(110px); }
+    & > .standard-legend {
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      opacity: 1;
+      transition: opacity .4s;
 
-    & > ul {
-      margin: 0;
-      padding: 0;
+      &.-hidden { opacity: 0; }
 
-      & > li {
-        list-style-type: none;
-        color: $color-10;
-        font-size: 13px;
-        line-height: 20px;
-        opacity: 1;
-        transition: opacity .3s;
+      & > ul {
+        margin: 0;
+        padding: 0;
 
-        > .icon {
-          width: 12px;
-          height: 12px;
-          display: inline-block;
-          padding-top: 1px;
-          margin-right: 5px;
+        & > li {
+          list-style-type: none;
+          color: $color-10;
+          font-size: 13px;
+          line-height: 20px;
+          opacity: 1;
+          transition: opacity .3s;
 
-          &.-large {
-            width: 30px;
-            padding-top: 2px;
-            margin-right: 10px;
+          > .icon {
+            width: 12px;
+            height: 12px;
+            display: inline-block;
+            padding-top: 1px;
+            margin-right: 5px;
+
+            &.-large {
+              width: 30px;
+              padding-top: 2px;
+              margin-right: 10px;
+            }
+
+            &.-actor  > use { color: $color-6; fill: transparent; }
+            &.-action > use { color: $color-7; fill: transparent; }
+            &.-monochrome > use { stroke: $color-15; }
+            &.-actors  > use { stroke: $color-6;  }
+            &.-actions > use { stroke: $color-7;  }
+            &.-mixed   > use { stroke: $color-19; }
           }
 
-          &.-actor  > use { color: $color-6; fill: transparent; }
-          &.-action > use { color: $color-7; fill: transparent; }
-          &.-monochrome > use { stroke: $color-15; }
-          &.-actors  > use { stroke: $color-6;  }
-          &.-actions > use { stroke: $color-7;  }
-          &.-mixed   > use { stroke: $color-19; }
-        }
+          &.title {
+            font-weight: 700;
+            text-transform: uppercase;
+            margin-bottom: 10px;
+          }
 
-        &.title {
-          font-weight: 700;
-          text-transform: uppercase;
-          margin-bottom: 10px;
+          &.-disabled { opacity: .3; }
         }
+      }
 
-        &.-disabled { opacity: .3; }
+      & > ul:not(ul:first-of-type) { flex-basis: 50%; }
+      & > ul:first-of-type {
+        flex-basis: 100%;
+        margin-bottom: 20px;
       }
     }
 
-    & > ul:not(ul:first-of-type) { flex-basis: 50%; }
-    & > ul:first-of-type         { flex-basis: 100%; margin-bottom: 20px; }
+    & > .alternative-legend {
+      position: absolute;
+      top: 15px;
+      left: 3px;
+      opacity: 1;
+      transition: opacity .4s;
+      width: calc(100% - 22px);
+      height: calc(100% - 15px);
+      overflow: scroll;
+      -webkit-overflow-scrolling: touch;
+
+      &.-hidden { opacity: 0; }
+
+      & > ul {
+        margin: 0;
+        padding: 0;
+
+        & > li {
+          list-style-type: none;
+          color: $color-10;
+          font-size: 13px;
+          line-height: 20px;
+          display: flex;
+          justify-content: space-between;
+
+          &.title {
+            font-weight: 700;
+            text-transform: uppercase;
+            margin-bottom: 10px;
+          }
+
+          > .icon {
+            height: 12px;
+            display: block;
+            padding-top: 1px;
+            flex-basis: 30px;
+
+            &.-large {
+              width: 30px;
+              padding-top: 2px;
+              margin-right: 10px;
+            }
+          }
+
+          > .label {
+            flex-basis: calc(100% - 35px);
+            text-transform: capitalize;
+          }
+        }
+      }
+    }
   }
 
   #map-slider {
@@ -129,9 +187,6 @@
     bottom: 0;
     background: none;
     transform: translateY(-213px);
-    transition: transform .4s;
-
-    &.-slided { transform: translateY(-103px); }
 
     & > *,
     & > *:hover {
@@ -173,10 +228,9 @@
       width: 26px;
       height: 26px;
       cursor: pointer;
-      transition: opacity .4s, transform .4s;
+      transition: opacity .4s;
 
       &.-disabled { cursor: default; opacity: .4; }
-      &.-slided   { transform: translateY(110px); }
     }
   }
 }

--- a/app/views/layouts/prototype.html.slim
+++ b/app/views/layouts/prototype.html.slim
@@ -15,51 +15,53 @@ html lang="en"
         #map
         = link_to (image_tag 'undp-logo-gradient.png', id: "logo"), "/prototype"
         #map-legend
-          ul
-            li.title
-              = t('front.relationships')
-            li.js-actor-to-action
-              svg.icon.-large.-monochrome
-                use xlink:href="#actorToActionIcon" x="0" y="4"
-              = t('front.actor_to_action')
-            li.js-actor-to-actor
-              svg.icon.-large.-monochrome
-                use xlink:href="#actorToActorIcon" x="0" y="4"
-              = t('front.actor_to_actor')
-            li.js-action-to-action
-              svg.icon.-large.-monochrome
-                use xlink:href="#actionToActionIcon" x="0" y="4"
-              = t('front.action_to_action')
-          ul
-            li.title
-              = t('front.actor')
-            li
-              svg.icon.-actor
-                use xlink:href="#macroMarkerIcon" x="-6" y="-6"
-              | Macro
-            li
-              svg.icon.-actor
-                use xlink:href="#mesoMarkerIcon" x="-4.5" y="-4"
-              | Meso
-            li
-              svg.icon.-actor
-                use xlink:href="#microMarkerIcon" x="-5" y="-3"
-              | Micro
-          ul
-            li.title
-              = t('front.action')
-            li
-              svg.icon.-action
-                use xlink:href="#macroMarkerIcon" x="-6" y="-6"
-              | Macro
-            li
-              svg.icon.-action
-                use xlink:href="#mesoMarkerIcon" x="-4.5" y="-4"
-              | Meso
-            li
-              svg.icon.-action
-                use xlink:href="#microMarkerIcon" x="-5" y="-3"
-              | Micro
+          .standard-legend.js-standard-legend
+            ul
+              li.title
+                = t('front.relationships')
+              li.js-actor-to-action
+                svg.icon.-large.-monochrome
+                  use xlink:href="#actorToActionIcon" x="0" y="6"
+                = t('front.actor_to_action')
+              li.js-actor-to-actor
+                svg.icon.-large.-monochrome
+                  use xlink:href="#actorToActorIcon" x="0" y="6"
+                = t('front.actor_to_actor')
+              li.js-action-to-action
+                svg.icon.-large.-monochrome
+                  use xlink:href="#actionToActionIcon" x="0" y="6"
+                = t('front.action_to_action')
+            ul
+              li.title
+                = t('front.actor')
+              li
+                svg.icon.-actor
+                  use xlink:href="#macroMarkerIcon" x="-6" y="-6"
+                | Macro
+              li
+                svg.icon.-actor
+                  use xlink:href="#mesoMarkerIcon" x="-4.5" y="-4"
+                | Meso
+              li
+                svg.icon.-actor
+                  use xlink:href="#microMarkerIcon" x="-5" y="-3"
+                | Micro
+            ul
+              li.title
+                = t('front.action')
+              li
+                svg.icon.-action
+                  use xlink:href="#macroMarkerIcon" x="-6" y="-6"
+                | Macro
+              li
+                svg.icon.-action
+                  use xlink:href="#mesoMarkerIcon" x="-4.5" y="-4"
+                | Meso
+              li
+                svg.icon.-action
+                  use xlink:href="#microMarkerIcon" x="-5" y="-3"
+                | Micro
+          .alternative-legend.-hidden.js-alternative-legend
         #map-slider
           a.slider-controls.js-play-button
             .left


### PR DESCRIPTION
This PR makes a change to the relationships graph mode: before, the relations used to have a color depending on the type of the two connected makers, now, their color depends on the type of relation. As the users are able to add as many types as they want, the colors are now computed instead of being hard-coded.

**IMPORTANT:** there's currently an issue with the API which doesn't return the coordinates of one of the extremities of the relations if they connect an actor or action which doesn't have a main location set. This implies that some relations displayed in the "normal" mode can be invisible in the graph.
Maybe you would like to wait for the issue to be fixed first (#114472271 on Pivotal).