### PR TITLE
Fix/layout of actors and actions index

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Please check all of [these points](https://github.com/Vizzuality/undp_cabo_verde
     -H "Accept: application/json; application/gfwc-v1+json" \
     -H "Content-Type: application/json"
 
-  Getting a specific country
+  Getting a specific actor
 
     curl "http://localhost:5000/api/actors/1" -X GET \
     -H "Accept: application/json; application/undp-cabo-verde-v1+json" \
@@ -126,6 +126,32 @@ Please check all of [these points](https://github.com/Vizzuality/undp_cabo_verde
 ```ruby
   rake docs:generate
 ```
+
+### Favourites Feature ###
+
+Sample for favourites links implementation on BO
+
+1. Add to the top of the controller that you wish to add to favourites feature:
+   include FavouriteActions
+   before_action :current_object,  only: [:create_favourite, :destroy_favourite]
+2. on controller bottom in private section define current_object like:
+   def current_object
+     @object = Actor.find(params[:id])
+   end
+3. Define in abilities like:
+   can [:create_favourite, :destroy_favourite], ::Actor
+4. Define the routes like:
+   resources :actors do
+     post   'create_favourite',  on: :member
+     delete 'destroy_favourite', on: :member
+   end
+5. Add to your template the partial for favourites links:
+   div
+     span.data
+       - if current_user
+         div id="#{actor.id}-favourites-buttons"
+           = render partial: 'shared/favourites_buttons', locals: { object: actor }
+
 
 ## DEPLOYMENT ##
 

--- a/app/views/actors/_actors.html.slim
+++ b/app/views/actors/_actors.html.slim
@@ -14,12 +14,12 @@
             = t("types.#{actor.type.constantize}")
           span.data
              = actor.status
-          span.data.-linkdata
-            - if actor.localizations.any?
-              = link_to prototype_path(anchor: "actors/#{actor.id}/#{actor.localizations.first.id}"), target: "_blank" do
-                = image_tag "map.svg", :class => "icon"
-                span
-                  = t("shared.view_map")
+          span.data.-linkdata class=('-disabled' unless actor.localizations.any?)
+            - path = actor.localizations.any? ? prototype_path(anchor: "actors/#{actor.id}/#{actor.localizations.first.id}") : "#"
+            = link_to path, target: "_blank" do
+              = image_tag "map.svg", :class => "icon"
+              span
+                = t("shared.view_map")
           span.data.-linkdata
             = link_to edit_actor_path(actor) do
               = image_tag "edit.svg", :class => "icon"

--- a/app/views/actors/_actors.html.slim
+++ b/app/views/actors/_actors.html.slim
@@ -9,29 +9,6 @@
             = "#{t('shared.created')}: #{actor.created_at.to_formatted_s(:create_update_date).to_s} / "
           span.data
             = "#{t('shared.updated')}: #{actor.updated_at.to_formatted_s(:short).to_s}"
-          / Sample for favourites links implementation on BO
-          / #####
-          / 1. Add to the top of the controller that you wish to add to favourites feature:
-          /    include FavouriteActions
-          /    before_action :current_object,  only: [:create_favourite, :destroy_favourite]
-          / 2. on controller bottom in private section define current_object like:
-          /    def current_object
-          /      @object = Actor.find(params[:id])
-          /    end
-          / 3. Define in abilities like:
-          /    can [:create_favourite, :destroy_favourite], ::Actor
-          / 4. Define the routes like:
-          /    resources :actors do
-          /      post   'create_favourite',  on: :member
-          /      delete 'destroy_favourite', on: :member
-          /    end
-          / 5. Add to your template the partial for favourites links:
-          /    div
-          /      span.data
-          /        - if current_user
-          /          div id="#{actor.id}-favourites-buttons"
-          /            = render partial: 'shared/favourites_buttons', locals: { object: actor }
-          / ##### That is it ;)
         .data-secondary
           span.data
             = t("types.#{actor.type.constantize}")

--- a/app/views/acts/_acts.html.slim
+++ b/app/views/acts/_acts.html.slim
@@ -15,12 +15,12 @@
             = t("types.#{act.type.constantize}")
           span.data
              = act.status
-          span.data.-linkdata
-            - if act.localizations.any?
-              = link_to prototype_path(anchor: "actions/#{act.id}/#{act.localizations.first.id}"), target: "_blank" do
-                = image_tag "map.svg", :class => "icon"
-                span
-                  = t("shared.view_map")
+          span.data.-linkdata class=('-disabled' unless act.localizations.any?)
+            - path = act.localizations.any? ? prototype_path(anchor: "actions/#{act.id}/#{act.localizations.first.id}") : "#"
+            = link_to path, target: "_blank" do
+              = image_tag "map.svg", :class => "icon"
+              span
+                = t("shared.view_map")
           span.data.-linkdata
             = link_to edit_act_path(act) do
               = image_tag "edit.svg", :class => "icon"


### PR DESCRIPTION
Currently if there weren't any locations for an actor or an action the layout of the index page of those, in the backoffice would break. This checks for this presence and handles it.