### PR TITLE
Removes hardcoded id, and replaces with a joined query

### DIFF
--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -266,8 +266,11 @@ class Actor < ActiveRecord::Base
     end
 
     def includes_actor_relations_belongs(child)
-      # relation_type_id: 2 for belongs to actor - actor relation
-      ActorRelation.where(relation_type_id: 2, child_id: child.id).pluck(:parent_id)
+      # Parent Location is defined as: "Contains" - "Belongs To"
+      ActorRelation.joins(:relation_type).
+        where("LOWER(relation_types.title) = :parent_relation OR LOWER(relation_types.title_reverse) = :parent_relation", parent_relation: "contains").
+        where(child_id: child.id).pluck(:parent_id)
+
     end
 
     def get_parents

--- a/app/views/actors/_form.html.slim
+++ b/app/views/actors/_form.html.slim
@@ -30,14 +30,14 @@
     .row
       .column.medium-8.medium-offset-4
         h2.form-title= t('localizations.localizations')
-    
+
     - unless @actor.new_record? || @actor.meso_or_macro?
       - unless common_form?
         .row
           .column.medium-8.medium-offset-4
             p.in-form-info
               = t('localizations.select_parent_location')
-        
+
     - if common_form? && @actor.localizations.empty? && @actor.parent_location_id.nil?
       .row
         .column.medium-8.medium-offset-4


### PR DESCRIPTION
Simple fix to the inherited relations issue.
If you have a Micro Actor with that Belongs to another actor you should be able to select that "parent" actors location as your own. This was not working because the id was hard-coded.