### PR TITLE
Changing the way actors relations are created

### DIFF
--- a/app/controllers/actors_controller.rb
+++ b/app/controllers/actors_controller.rb
@@ -124,7 +124,10 @@ class ActorsController < ApplicationController
       @types          = type_class.types.map { |t| [t("types.#{t.constantize}", default: t.constantize), t.camelize] }
       @macros         = ActorMacro.order(:name).filter_actives
       @mesos          = ActorMeso.order(:name).filter_actives
-      @actor_relation_types   = RelationType.order(:title).includes_actor_relations.collect     { |rt| [ rt.title, rt.id ] }
+      @actor_relation_types   = RelationType.order(:title).
+        includes_actor_relations.collect     { |rt| [ rt.title, rt.id ] }
+      @actor_reverse_relation_types   = RelationType.order(:title_reverse).
+        includes_actor_relations.collect     { |rt| [ rt.title_reverse, rt.id ] }
       @action_relation_types  = RelationType.order(:title).includes_actor_act_relations.collect { |rt| [ rt.title, rt.id ] }
       @organization_types     = Category.ot_categories
       @socio_cultural_domains = Category.scd_categories

--- a/app/controllers/acts_controller.rb
+++ b/app/controllers/acts_controller.rb
@@ -133,7 +133,7 @@ class ActsController < ApplicationController
       @units                  = Unit.order(:name)
       @actor_relation_types           = RelationType.order(:title).includes_actor_act_relations.collect     { |rt| [ rt.title_reverse, rt.id ] }
       @action_relation_types          = RelationType.order(:title).includes_act_relations.collect           { |rt| [ rt.title, rt.id ]         }
-      @action_relation_children_types = RelationType.order(:title).includes_act_relations.collect           { |rt| [ rt.title_reverse, rt.id ] }
+      @action_reverse_relation_types = RelationType.order(:title).includes_act_relations.collect           { |rt| [ rt.title_reverse, rt.id ] }
       @indicator_relation_types       = RelationType.order(:title).includes_act_indicator_relations.collect { |rt| [ rt.title, rt.id ]         }
     end
 

--- a/app/views/actors/_actor_relation_children_form.html.slim
+++ b/app/views/actors/_actor_relation_children_form.html.slim
@@ -22,19 +22,20 @@
           = @actor.name
   .row
     .column.medium-4
-      = f.label :relation_type_id, t('* ') + t('actors.relation_name'), class: 'right inline', disabled: common_form?
+      = f.label :relation_type_id, t('* ') + t('actors.relation_name'),
+        class: 'right inline highlight-label', disabled: common_form?
     .column.medium-8
-      = f.input :relation_type_id, collection: @actor_relation_types, as: :collection_select, label: false, input_html: { class: 'chosen-select relation_type_id' }, disabled: common_form?
+      = f.input :relation_type_id, collection: @actor_relation_types, as: :collection_select,
+        label: false, input_html: { class: 'chosen-select relation_type_id' }, disabled: common_form?
+  - unless common_form?
+    .row
+      .column.medium-8.medium-offset-4
+        = link_to t('relations.switch'), '#', class: 'switch_parent_form switch-link'
   .row
     .column.medium-4
       = f.label :child_id, t('* ') + t('actors.actor'), class: 'right inline', disabled: common_form?
     .column.medium-8
       = f.input :child_id, collection: preview ? @all_children_to_select : @children_to_select, as: :collection_select, label: false, input_html: { multiple: false, class: 'chosen-select collection_select relation_child_id' }, disabled: common_form?
-
-  - unless common_form?
-    .row
-      .column.medium-8.medium-offset-4
-        = link_to t('relations.switch'), '#', class: 'switch_parent_form switch-link'
   .row
     .column.medium-4
       = f.label :start_date, class: 'right inline', disabled: common_form?

--- a/app/views/actors/_actor_relation_form.html.slim
+++ b/app/views/actors/_actor_relation_form.html.slim
@@ -13,16 +13,6 @@
 .form-inputs.form-inputs-parent.form-inputs-relations.actor-actor-relation class=('hide' if preview) id=("expanded-actors-relation-#{f.object.id}" if preview)
   .row
     .column.medium-4
-      = f.label :parent_id, t('* ') + t('actors.actor'), class: 'right inline', disabled: common_form?
-    .column.medium-8
-      = f.input :parent_id, collection: preview ? @all_parents_to_select : @parents_to_select, as: :collection_select, label: false, input_html: { multiple: false, class: 'chosen-select relation_parent_id collection_select' }, disabled: common_form?
-  .row
-    .column.medium-4
-      = f.label :relation_type_id, t('* ') + t('actors.relation_name'), class: 'right inline', disabled: common_form?
-    .column.medium-8
-      = f.input :relation_type_id, collection: @actor_relation_types, as: :collection_select, label: false, input_html: { class: 'chosen-select relation_type_id' }, disabled: common_form?
-  .row
-    .column.medium-4
       = f.label t('actors.current_actor'), class: 'right inline', disabled: common_form?
     .column.medium-8.text-left.current-actor-wrapper
       - if @actor.new_record?
@@ -30,10 +20,21 @@
       - else
         p.current-actor-edit.-disabled
           = @actor.name
+  .row
+    .column.medium-4
+      = f.label :relation_type_id, t('* ') + t('actors.reverse_relation_name'),
+        class: 'right inline highlight-label', disabled: common_form?
+    .column.medium-8
+      = f.input :relation_type_id, collection: @actor_reverse_relation_types, as: :collection_select, label: false, input_html: { class: 'chosen-select relation_type_id' }, disabled: common_form?
   - unless common_form?
     .row
       .column.medium-8.medium-offset-4
         = link_to t('relations.switch'), '#', class: 'switch_child_form switch-link'
+  .row
+    .column.medium-4
+      = f.label :parent_id, t('* ') + t('actors.actor'), class: 'right inline', disabled: common_form?
+    .column.medium-8
+      = f.input :parent_id, collection: preview ? @all_parents_to_select : @parents_to_select, as: :collection_select, label: false, input_html: { multiple: false, class: 'chosen-select relation_parent_id collection_select' }, disabled: common_form?
   .row
     .column.medium-4
       = f.label :start_date, class: 'right inline', disabled: common_form?

--- a/app/views/acts/_action_relation_children_form.html.slim
+++ b/app/views/acts/_action_relation_children_form.html.slim
@@ -15,26 +15,28 @@
     .column.medium-4
       = f.label t('acts.current_action'), class: 'right inline', disabled: common_form?
     .column.medium-8.text-left.current-action-wrapper
-      - if request.path.include?('/actions/new')
+      - if @act.new_record?
         p.current-action.-disabled
       - else
         p.current-action-edit.-disabled
-          = @act.name unless request.path.include?('/actions/new')
+          = @act.name
   .row
     .column.medium-4
       = f.label :relation_type_id, "* " + t('actors.relation_name'), class: 'right inline', disabled: common_form?
     .column.medium-8
       = f.input :relation_type_id, collection: @action_relation_types, as: :collection_select, label: false, input_html: { class: 'chosen-select relation_type_id' }, disabled: common_form?
-  .row
-    .column.medium-4
-      = f.label :child_id, "* " + t('acts.act'), class: 'right inline', disabled: common_form?
-    .column.medium-8
-      = f.input :child_id, collection: preview ? @all_children_to_select : @children_to_select, as: :collection_select, label: false, input_html: { multiple: false, class: 'chosen-select collection_select relation_child_id' }, disabled: common_form?
-
   - unless common_form?
     .row
       .column.medium-8.medium-offset-4
         = link_to t('relations.switch'), '#', class: 'switch_parent_form switch-link'
+  .row
+    .column.medium-4
+      = f.label :child_id, "* " + t('acts.act'), class: 'right inline', disabled: common_form?
+    .column.medium-8
+      = f.input :child_id, collection: preview ? @all_children_to_select : @children_to_select,
+        as: :collection_select, label: false,
+        input_html: { multiple: false, class: 'chosen-select collection_select relation_child_id' },
+        disabled: common_form?
 
   .row
     .column.medium-4

--- a/app/views/acts/_action_relation_form.html.slim
+++ b/app/views/acts/_action_relation_form.html.slim
@@ -13,28 +13,31 @@
 .form-inputs.form-inputs-parent.form-inputs-relations.action-action-relation class=('hide' if preview) id=("expanded-actions-relation-#{f.object.id}" if preview)
   .row
     .column.medium-4
-      = f.label :parent_id, "* " + t('acts.act'), class: 'right inline', disabled: common_form?
-    .column.medium-8
-      = f.input :parent_id, collection: preview ? @all_parents_to_select : @parents_to_select, as: :collection_select, label: false, input_html: { multiple: false, class: 'chosen-select collection_select relation_parent_id' }, disabled: common_form?
-  .row
-    .column.medium-4
-      = f.label :relation_type_id, "* " + t('actors.relation_name'), class: 'right inline', disabled: common_form?
-    .column.medium-8
-      = f.input :relation_type_id, collection: @action_relation_types, as: :collection_select, label: false, input_html: { class: 'chosen-select relation_type_id' }, disabled: common_form?
-  .row
-    .column.medium-4
       = f.label t('acts.current_action'), class: 'right inline', disabled: common_form?
     .column.medium-8.text-left.current-action-wrapper
-      - if request.path.include?('/actions/new')
+      - if @act.new_record?
         p.current-action.-disabled
       - else
         p.current-action-edit.-disabled
-          = @act.name unless request.path.include?('/actions/new')
-
+          = @act.name
+  .row
+    .column.medium-4
+      = f.label :relation_type_id, "* " + t('actors.reverse_relation_name'),
+        class: 'right inline', disabled: common_form?
+    .column.medium-8
+      = f.input :relation_type_id, collection: @action_reverse_relation_types,
+        as: :collection_select, label: false,
+        input_html: { class: 'chosen-select relation_type_id' },
+        disabled: common_form?
   - unless common_form?
     .row
       .column.medium-8.medium-offset-4
         = link_to t('relations.switch'), '#', class: 'switch_child_form switch-link'
+  .row
+    .column.medium-4
+      = f.label :parent_id, "* " + t('acts.act'), class: 'right inline', disabled: common_form?
+    .column.medium-8
+      = f.input :parent_id, collection: preview ? @all_parents_to_select : @parents_to_select, as: :collection_select, label: false, input_html: { multiple: false, class: 'chosen-select collection_select relation_parent_id' }, disabled: common_form?
 
   .row
     .column.medium-4

--- a/app/views/acts/_actor_relation_form.html.slim
+++ b/app/views/acts/_actor_relation_form.html.slim
@@ -26,7 +26,7 @@
           = @act.name
   .row
     .column.medium-4
-      = f.label :relation_type_id, "* " + t('acts.current_action'),
+      = f.label :relation_type_id, "* " + t('acts.relation_name'),
         class: 'right inline', disabled: common_form?
     .column.medium-8
       = f.input :relation_type_id, collection: @actor_relation_types,

--- a/app/views/acts/_form.html.slim
+++ b/app/views/acts/_form.html.slim
@@ -114,7 +114,7 @@
             - unless common_form?
               p.text-right.add-button
                 / Add more css classes to 'add_actor', sample 'add_actor your_class_name'
-                = add_actor_relation_path t('relations.add_relation'), form, :act_actor_relations, 'add_fields add_actor add_actors_fields'
+                = add_actor_relation_path t('relations.add_relation'), form, :act_actor_relations, 'add_actor add_actors_fields'
 
           div#action_relation_form.content
             = form.fields_for :act_relations_as_child do |action_parents_form|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -288,7 +288,8 @@ en:
     current_actor: 'Current actor'
     to_current_actor: 'To current actor'
     to_actor: 'To actor'
-    relation_name: 'Relation title'
+    relation_name: 'Relation'
+    reverse_relation_name: 'Reverse relation'
     main: 'Main location'
 
   acts:

--- a/features/actors.feature
+++ b/features/actors.feature
@@ -200,7 +200,7 @@ I want to manage an actor
     Then I should see "Person one" within ".current-actor-wrapper"
     When I click on overlapping ".switch_parent_form"
     And I select from the following hidden field ".relation_parent_id" with "Organization one"
-    And I select from the following hidden field ".relation_type_id" with "contains"
+    And I select from the following hidden field ".relation_type_id" with "belongs to"
     When I fill in the following field ".relation_start_date" with "1990-03-10"
     When I fill in the following field ".relation_end_date" with "2010-03-10"
     And I press "Update"

--- a/features/acts.feature
+++ b/features/acts.feature
@@ -176,7 +176,7 @@ I want to manage an act
     Then I should see "Third one" within ".current-action-wrapper"
     When I click on ".switch_parent_form"
     And I select from the following hidden field ".relation_parent_id" with "Second one"
-    And I select from the following hidden field ".relation_type_id" with "contains"
+    And I select from the following hidden field ".relation_type_id" with "belongs to"
     When I fill in the following field ".relation_start_date" with "1990-03-10"
     When I fill in the following field ".relation_end_date" with "2010-03-10"
     And I press "Update"


### PR DESCRIPTION
Mostly display changes in the backoffice.

Now form will read:

* Current actor > Contains > another actor
or after switching
* Current actor > Belongs to > another actor